### PR TITLE
refactor: Use data registration

### DIFF
--- a/cosmos_predict2/configs/base/defaults/data.py
+++ b/cosmos_predict2/configs/base/defaults/data.py
@@ -18,9 +18,13 @@ from hydra.core.config_store import ConfigStore
 from cosmos_predict2.datasets.cached_replay_dataloader import get_cached_replay_dataloader
 from cosmos_predict2.datasets.data_sources.mock_data import get_image_dataset, get_video_dataset
 from cosmos_predict2.datasets.joint_dataloader import IterativeJointDataLoader
+from cosmos_predict2.data.dataset_video import Dataset
 from imaginaire.lazy_config import LazyCall as L
+from megatron.core import parallel_state
+from torch.utils.data import DataLoader, DistributedSampler
 
-_IMAGE_LOADER = L(get_cached_replay_dataloader)(
+
+mock_image_dataloader = L(get_cached_replay_dataloader)(
     dataset=L(get_image_dataset)(
         resolution="512",
     ),
@@ -32,7 +36,7 @@ _IMAGE_LOADER = L(get_cached_replay_dataloader)(
     cache_replay_name="image_dataloader",
 )
 
-_VIDEO_LOADER = L(get_cached_replay_dataloader)(
+mock_video_dataloader = L(get_cached_replay_dataloader)(
     dataset=L(get_video_dataset)(
         resolution="512",
         num_video_frames=136,  # number of pixel frames, the number needs to agree with tokenizer encoder since tokenizer can not handle arbitrary length
@@ -45,27 +49,50 @@ _VIDEO_LOADER = L(get_cached_replay_dataloader)(
     cache_replay_name="video_dataloader",
 )
 
-MOCK_DATA_INTERLEAVE_CONFIG = L(IterativeJointDataLoader)(
+mock_interleaved_dataloader = L(IterativeJointDataLoader)(
     dataloaders={
         "image_data": {
-            "dataloader": _IMAGE_LOADER,
+            "dataloader": mock_image_dataloader,
             "ratio": 1,
         },
         "video_data": {
-            "dataloader": _VIDEO_LOADER,
+            "dataloader": mock_video_dataloader,
             "ratio": 1,
         },
     }
 )
 
-MOCK_DATA_IMAGE_ONLY_CONFIG = _IMAGE_LOADER
 
-MOCK_DATA_VIDEO_ONLY_CONFIG = _VIDEO_LOADER
+# Cosmos-NeMo-Assets example
+def get_sampler(dataset) -> DistributedSampler:
+    return DistributedSampler(
+        dataset,
+        num_replicas=parallel_state.get_data_parallel_world_size(),
+        rank=parallel_state.get_data_parallel_rank(),
+        shuffle=True,
+        seed=0,
+    )
 
+example_video_dataset_cosmos_nemo_assets = L(Dataset)(
+    dataset_dir="datasets/benchmark_train/cosmos_nemo_assets",
+    num_frames=77,
+    video_size=(720, 1280),
+)
+
+dataloader_train_cosmos_nemo_assets = L(DataLoader)(
+    dataset=example_video_dataset_cosmos_nemo_assets,
+    sampler=L(get_sampler)(dataset=example_video_dataset_cosmos_nemo_assets),
+    batch_size=1,
+    drop_last=True,
+    num_workers=8,
+    pin_memory=True,
+)
 
 def register_training_and_val_data():
     cs = ConfigStore()
-    cs.store(group="data_train", package="dataloader_train", name="mock", node=MOCK_DATA_INTERLEAVE_CONFIG)
-    cs.store(group="data_train", package="dataloader_train", name="mock_image", node=MOCK_DATA_IMAGE_ONLY_CONFIG)
-    cs.store(group="data_train", package="dataloader_train", name="mock_video", node=MOCK_DATA_VIDEO_ONLY_CONFIG)
-    cs.store(group="data_val", package="dataloader_val", name="mock", node=MOCK_DATA_INTERLEAVE_CONFIG)
+    cs.store(group="data_train", package="dataloader_train", name="cosmos_nemo_assets", node=dataloader_train_cosmos_nemo_assets)
+    cs.store(group="data_train", package="dataloader_train", name="mock", node=mock_interleaved_dataloader)
+    cs.store(group="data_train", package="dataloader_train", name="mock_image", node=mock_image_dataloader)
+    cs.store(group="data_train", package="dataloader_train", name="mock_video", node=mock_video_dataloader)
+    cs.store(group="data_val", package="dataloader_val", name="mock", node=mock_interleaved_dataloader)
+


### PR DESCRIPTION
## Motivation

The original implementation specified the `dataloader_train` in the config and didn't use `{"override /data_train": "cosmos_nemo_assets"},`. This forbids users from using mock data via command line override.

## Changes

- Register `dataloader_train_cosmos_nemo_assets` in `data.py`.
- Use `{"override /data_train": "cosmos_nemo_assets"},` for users to easily switch between training dataloader.