### PR TITLE
Optimize offloading

### DIFF
--- a/documentations/inference_video2world.md
+++ b/documentations/inference_video2world.md
@@ -56,7 +56,21 @@ python -m examples.video2world \
     --save_path output/video2world_2b.mp4
 ```
 
-The 14B model can be run similarly by changing the model size parameter.
+The 14B model can be run similarly by changing the model size parameter. For GPUs with lower memory limit, it may also make sense to offload guardrail and prompt refiner models.
+
+```bash
+# Set the input prompt
+PROMPT="A nighttime city bus terminal gradually shifts from stillness to subtle movement. At first, multiple double-decker buses are parked under the glow of overhead lights, with a central bus labeled '87D' facing forward and stationary. As the video progresses, the bus in the middle moves ahead slowly, its headlights brightening the surrounding area and casting reflections onto adjacent vehicles. The motion creates space in the lineup, signaling activity within the otherwise quiet station. It then comes to a smooth stop, resuming its position in line. Overhead signage in Chinese characters remains illuminated, enhancing the vibrant, urban night scene."
+# Run video2world generation
+python -m examples.video2world \
+    --model_size 14B \
+    --input_path assets/video2world/input0.jpg \
+    --num_conditional_frames 1 \
+    --prompt "${PROMPT}" \
+    --save_path output/video2world_14b.mp4 \
+    --offload_guardrail \
+    --offload_prompt_refiner
+```
 
 ### Batch Video Generation
 
@@ -267,6 +281,9 @@ Content safety and controls:
 - `--disable_guardrail`: Disable guardrail checks on prompts (by default, guardrails are enabled to filter harmful content)
 - `--disable_prompt_refiner`: Disable prompt refiner that enhances short prompts (by default, the prompt refiner is enabled)
 
+GPU memory controls:
+- `--offload_guardrail`: Offload guardrail to CPU to save GPU memory
+- `--offload_prompt_refiner`: Offload prompt refiner to CPU to save GPU memory
 ## Specialized Scripts
 
 In addition to the main `video2world.py` script, there are specialized variants for specific use cases:

--- a/examples/video2world.py
+++ b/examples/video2world.py
@@ -125,8 +125,12 @@ def parse_args() -> argparse.Namespace:
         help="Number of GPUs to use for context parallel inference (should be a divisor of the total frames)",
     )
     parser.add_argument("--disable_guardrail", action="store_true", help="Disable guardrail checks on prompts")
+    parser.add_argument("--offload_guardrail", action="store_true", help="Offload guardrail to CPU to save GPU memory")
     parser.add_argument(
         "--disable_prompt_refiner", action="store_true", help="Disable prompt refiner that enhances short prompts"
+    )
+    parser.add_argument(
+        "--offload_prompt_refiner", action="store_true", help="Offload prompt refiner to CPU to save GPU memory"
     )
     return parser.parse_args()
 
@@ -165,11 +169,13 @@ def setup_pipeline(args: argparse.Namespace):
     if args.disable_guardrail:
         log.warning("Guardrail checks are disabled")
         config.guardrail_config.enabled = False
+    config.guardrail_config.offload_model_to_cpu = args.offload_guardrail
 
     # Disable prompt refiner if requested
     if args.disable_prompt_refiner:
         log.warning("Prompt refiner is disabled")
         config.prompt_refiner_config.enabled = False
+    config.prompt_refiner_config.offload_model_to_cpu = args.offload_prompt_refiner
 
     # Load models
     log.info(f"Initializing Video2WorldPipeline with model size: {args.model_size}")


### PR DESCRIPTION
- This MR optimizes the offloading of guardrails and adds an argument to `examples/video2world.py` script to enable it by command line, without requiring config change.
- Right now video guardrail offloads the guardrail model to CPU after analyzing each frame, which is very inefficient. We can only offload the model once after the entire video was analyzed. **That saves us 115s on an AWS H100 hardware.**
- Right now the prompt refinements and guardrails models are always offloaded, even for a 2B model. This MR adds an option to change it dynamically with a script argument. We also modify the README to show an example of offloading for a 14B model.
- **Note that with this change the offloading will be disabled by default if `--offload_guardrail` and `--offload_prompt_refinement` is not passed to the script. Let me know if we'd like it the other way around.**

To sum it up:

- Before this change the models were always offloaded inefficiently, which caused ~135s of overhead related to offloading.
- With this change the models are not offloaded by default. When we do enable the offloading with script parameters, the offloading causes only ~20s of overhead.

