### PR TITLE
Added benchmarking option to inference scripts

### DIFF
--- a/examples/text2image.py
+++ b/examples/text2image.py
@@ -20,6 +20,7 @@ import os
 # Set TOKENIZERS_PARALLELISM environment variable to avoid deadlocks with multiprocessing
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
+import time
 import torch
 from tqdm import tqdm
 
@@ -59,6 +60,11 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--use_cuda_graphs", action="store_true", help="Use CUDA Graphs for the inference.")
     parser.add_argument("--disable_guardrail", action="store_true", help="Disable guardrail checks on prompts")
+    parser.add_argument(
+        "--benchmark",
+        action="store_true",
+        help="Run the generation in benchmark mode. It means that generation will be rerun a few times and the average generation time will be shown."
+    )
     return parser.parse_args()
 
 
@@ -98,16 +104,28 @@ def setup_pipeline(args: argparse.Namespace) -> Text2ImagePipeline:
     return pipe
 
 
-def process_single_generation(pipe, prompt, output_path, negative_prompt, seed, use_cuda_graphs):
+def process_single_generation(pipe, prompt, output_path, negative_prompt, seed, use_cuda_graphs, benchmark):
     log.info(f"Running Text2ImagePipeline\nprompt: {prompt}")
 
-    # Generate image
-    image = pipe(
-        prompt=prompt,
-        negative_prompt=negative_prompt,
-        seed=seed,
-        use_cuda_graphs=use_cuda_graphs,
-    )
+    # When benchmarking, run inference 4 times, exclude the 1st due to warmup and average time.
+    num_repeats = 4 if benchmark else 1
+    time_sum = 0
+    for i in range(num_repeats):
+        # Generate image
+        if benchmark and i > 0:
+            torch.cuda.synchronize()
+            start_time = time.time()
+        image = pipe(
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            seed=seed,
+            use_cuda_graphs=use_cuda_graphs,
+        )
+        if benchmark and i > 0:
+            torch.cuda.synchronize()
+            time_sum += time.time() - start_time
+    if benchmark:
+        log.critical(f"The benchmarked generation time for Text2ImagePipeline is {time_sum / 3} seconds.")
 
     if image is not None:
         # save the generated image
@@ -144,6 +162,7 @@ def generate_image(args: argparse.Namespace, pipe: Text2ImagePipeline) -> None:
                 negative_prompt=args.negative_prompt,
                 seed=args.seed,
                 use_cuda_graphs=args.use_cuda_graphs,
+                benchmark=args.benchmark,
             )
     else:
         if args.use_cuda_graphs:
@@ -157,6 +176,7 @@ def generate_image(args: argparse.Namespace, pipe: Text2ImagePipeline) -> None:
             negative_prompt=args.negative_prompt,
             seed=args.seed,
             use_cuda_graphs=args.use_cuda_graphs,
+            benchmark=args.benchmark,
         )
 
     return

--- a/examples/text2image.py
+++ b/examples/text2image.py
@@ -140,6 +140,8 @@ def process_single_generation(pipe, prompt, output_path, negative_prompt, seed, 
 
 
 def generate_image(args: argparse.Namespace, pipe: Text2ImagePipeline) -> None:
+    if args.benchmark:
+        log.warning("Running in benchmark mode. Each generation will be rerun a couple of times and the average generation time will be shown.")
     # Text-to-image
     if args.batch_input_json is not None:
         # Process batch inputs from JSON file

--- a/examples/text2world.py
+++ b/examples/text2world.py
@@ -85,6 +85,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--disable_prompt_refiner", action="store_true", help="Disable prompt refiner that enhances short prompts"
     )
+    parser.add_argument(
+        "--benchmark",
+        action="store_true",
+        help="Run the generation in benchmark mode. It means that generation will be rerun a few times and the average generation time will be shown."
+    )
     return parser.parse_args()
 
 
@@ -205,6 +210,7 @@ def generate_video(args: argparse.Namespace, pipelines: Tuple[Text2ImagePipeline
                 negative_prompt=args.negative_prompt,
                 seed=args.seed,
                 use_cuda_graphs=args.use_cuda_graphs,
+                benchmark=args.benchmark,
             ):
                 # Save the item for the second stage
                 batch_items.append({"prompt": prompt, "output_video": output_video, "temp_image_path": temp_image_name})
@@ -222,6 +228,7 @@ def generate_video(args: argparse.Namespace, pipelines: Tuple[Text2ImagePipeline
             negative_prompt=args.negative_prompt,
             seed=args.seed,
             use_cuda_graphs=args.use_cuda_graphs,
+            benchmark=args.benchmark,
         ):
             # Add single item to batch_items for consistent processing
             batch_items.append(
@@ -244,6 +251,7 @@ def generate_video(args: argparse.Namespace, pipelines: Tuple[Text2ImagePipeline
             num_conditional_frames=1,  # Always use 1 frame for text2world
             guidance=args.guidance,
             seed=args.seed,
+            benchmark=args.benchmark,
         )
 
         # Clean up the temporary image file

--- a/examples/text2world.py
+++ b/examples/text2world.py
@@ -171,6 +171,8 @@ def setup_pipeline(args: argparse.Namespace) -> Tuple[Text2ImagePipeline, Video2
 
 
 def generate_video(args: argparse.Namespace, pipelines: Tuple[Text2ImagePipeline, Video2WorldPipeline]) -> None:
+    if args.benchmark:
+        log.warning("Running in benchmark mode. Each generation will be rerun a couple of times and the average generation time will be shown.")
     text2image_pipe, video2world_pipe = pipelines
 
     # Get the base path for temporary image (without file extension)

--- a/examples/video2world.py
+++ b/examples/video2world.py
@@ -269,6 +269,8 @@ def process_single_generation(
 
 
 def generate_video(args: argparse.Namespace, pipe: Video2WorldPipeline) -> None:
+    if args.benchmark:
+        log.warning("Running in benchmark mode. Each generation will be rerun a couple of times and the average generation time will be shown.")
     # Video-to-World
     if args.batch_input_json is not None:
         # Process batch inputs from JSON file
@@ -294,6 +296,7 @@ def generate_video(args: argparse.Namespace, pipe: Video2WorldPipeline) -> None:
                 num_conditional_frames=args.num_conditional_frames,
                 guidance=args.guidance,
                 seed=args.seed,
+                benchmark=args.benchmark,
             )
     else:
         process_single_generation(
@@ -305,6 +308,7 @@ def generate_video(args: argparse.Namespace, pipe: Video2WorldPipeline) -> None:
             num_conditional_frames=args.num_conditional_frames,
             guidance=args.guidance,
             seed=args.seed,
+            benchmark=args.benchmark,
         )
 
     return

--- a/examples/video2world.py
+++ b/examples/video2world.py
@@ -20,6 +20,7 @@ import os
 # Set TOKENIZERS_PARALLELISM environment variable to avoid deadlocks with multiprocessing
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
+import time
 import torch
 from megatron.core import parallel_state
 from tqdm import tqdm
@@ -146,6 +147,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--offload_prompt_refiner", action="store_true", help="Offload prompt refiner to CPU to save GPU memory"
     )
+    parser.add_argument(
+        "--benchmark",
+        action="store_true",
+        help="Run the generation in benchmark mode. It means that generation will be rerun a few times and the average generation time will be shown."
+    )
     return parser.parse_args()
 
 
@@ -217,7 +223,7 @@ def setup_pipeline(args: argparse.Namespace):
 
 
 def process_single_generation(
-    pipe, input_path, prompt, output_path, negative_prompt, num_conditional_frames, guidance, seed
+    pipe, input_path, prompt, output_path, negative_prompt, num_conditional_frames, guidance, seed, benchmark
 ):
     # Validate input file
     if not validate_input_file(input_path, num_conditional_frames):
@@ -226,14 +232,25 @@ def process_single_generation(
 
     log.info(f"Running Video2WorldPipeline\ninput: {input_path}\nprompt: {prompt}")
 
-    video = pipe(
-        prompt=prompt,
-        negative_prompt=negative_prompt,
-        input_path=input_path,
-        num_conditional_frames=num_conditional_frames,
-        guidance=guidance,
-        seed=seed,
-    )
+    num_repeats = 4 if benchmark else 1
+    time_sum = 0
+    for i in range(num_repeats):
+        if benchmark and i > 0:
+            torch.cuda.synchronize()
+            start_time = time.time()
+        video = pipe(
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            input_path=input_path,
+            num_conditional_frames=num_conditional_frames,
+            guidance=guidance,
+            seed=seed,
+        )
+        if benchmark and i > 0:
+            torch.cuda.synchronize()
+            time_sum += time.time() - start_time
+    if benchmark:
+        log.critical(f"The benchmarked generation time for Video2WorldPipeline is {time_sum / 3} seconds.")
 
     if video is not None:
         # save the generated video


### PR DESCRIPTION
This PR adds a new command line argument `--benchmark` to `examples/video2world.py`, `examples/text2image.py` and `examples/text2world.pt` inference scripts. When this option is enabled, the generation will be run 4 times - the first one will be ignored as a warmup iteration, and the following 3 times will be timed and averaged out to print the average generation time.