### PR TITLE
Added CLI arguments to offload guardrails and prompt refiner

### DIFF
--- a/examples/text2image.py
+++ b/examples/text2image.py
@@ -59,6 +59,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--use_cuda_graphs", action="store_true", help="Use CUDA Graphs for the inference.")
     parser.add_argument("--disable_guardrail", action="store_true", help="Disable guardrail checks on prompts")
+    parser.add_argument("--offload_guardrail", action="store_true", help="Offload guardrail to CPU to save GPU memory")
     return parser.parse_args()
 
 
@@ -77,6 +78,7 @@ def setup_pipeline(args: argparse.Namespace) -> Text2ImagePipeline:
     if args.disable_guardrail:
         log.warning("Guardrail checks are disabled")
         config.guardrail_config.enabled = False
+    config.guardrail_config.offload_model_to_cpu = args.offload_guardrail
 
     misc.set_random_seed(seed=args.seed, by_rank=True)
     # Initialize cuDNN.

--- a/examples/text2world.py
+++ b/examples/text2world.py
@@ -82,8 +82,12 @@ def parse_args() -> argparse.Namespace:
         help="Number of GPUs to use for context parallel inference in the video2world part",
     )
     parser.add_argument("--disable_guardrail", action="store_true", help="Disable guardrail checks on prompts")
+    parser.add_argument("--offload_guardrail", action="store_true", help="Offload guardrail to CPU to save GPU memory")
     parser.add_argument(
         "--disable_prompt_refiner", action="store_true", help="Disable prompt refiner that enhances short prompts"
+    )
+    parser.add_argument(
+        "--offload_prompt_refiner", action="store_true", help="Offload prompt refiner to CPU to save GPU memory"
     )
     return parser.parse_args()
 
@@ -116,11 +120,14 @@ def setup_pipeline(args: argparse.Namespace) -> Tuple[Text2ImagePipeline, Video2
         log.warning("Guardrail checks are disabled")
         config_text2image.guardrail_config.enabled = False
         config_video2world.guardrail_config.enabled = False
+    config_text2image.guardrail_config.offload_model_to_cpu = args.offload_guardrail
+    config_video2world.guardrail_config.offload_model_to_cpu = args.offload_guardrail
 
     # Disable prompt refiner if requested
     if args.disable_prompt_refiner:
         log.warning("Prompt refiner is disabled")
         config_video2world.prompt_refiner_config.enabled = False
+    config_video2world.prompt_refiner_config.offload_model_to_cpu = args.offload_prompt_refiner
 
     misc.set_random_seed(seed=args.seed, by_rank=True)
     # Initialize cuDNN.


### PR DESCRIPTION
This PR adds a CLI arguments `--offload_guardrail` and `--offload_prompt_refiner`  to control offloading of guardrails and prompt refiner in `examples/text2image.py` and `examples/text2video.py` scripts. Previously we only had this option in `examples/video2world.py` script. 

Additionally, same as for `examples/video2world.py`, the offloading will be now disabled by default and we'll need to pass this option if we want to enable offloading. The offloading is not needed on most of data-center GPUs, especially for 2B models, and having it enabled by default can unnecessarily hurt performance. The current benchmarking numbers we have were done with offloading disabled.