### PR TITLE
Add docker build recipe for ARM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,44 @@
 # Use NVIDIA PyTorch container as base image
 FROM nvcr.io/nvidia/pytorch:25.04-py3
+ARG TARGETPLATFORM
 
 # Install basic tools
 RUN apt-get update && apt-get install -y git tree ffmpeg wget
-RUN rm /bin/sh && ln -s /bin/bash /bin/sh && ln -s /lib64/libcuda.so.1 /lib64/libcuda.so
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+RUN if [[ ${TARGETPLATFORM} == 'linux/amd64' ]]; then ln -s /lib64/libcuda.so.1 /lib64/libcuda.so; fi
 RUN apt-get install -y libglib2.0-0
 RUN sed -i -e 's/h11==0.14.0/h11==0.16.0/g' /etc/pip/constraint.txt
 
-# Install the dependencies from requirements-docker.txt
-COPY ./requirements-docker.txt /requirements.txt
-RUN pip install --no-cache-dir -r /requirements.txt
 # Install Flash Attention 3
 RUN MAX_JOBS=$(( $(nproc) / 4 )) pip install git+https://github.com/Dao-AILab/flash-attention.git@27f501d#subdirectory=hopper
 COPY cosmos_predict2/utils/flash_attn_3/flash_attn_interface.py /usr/local/lib/python3.12/dist-packages/flash_attn_3/flash_attn_interface.py
 COPY cosmos_predict2/utils/flash_attn_3/te_attn.diff /tmp/te_attn.diff
 RUN patch /usr/local/lib/python3.12/dist-packages/transformer_engine/pytorch/attention.py /tmp/te_attn.diff
 
+COPY Video_Codec_SDK_13.0.19.zip* /workspace/Video_Codec_SDK_13.0.19.zip
+# Installing decord from source on ARM
+RUN if [[ ${TARGETPLATFORM} == 'linux/arm64' ]]; then export DEBIAN_FRONTEND=noninteractive && \
+apt-get update && \
+apt-get install -y build-essential python3-dev python3-setuptools make cmake \
+                   ffmpeg libavcodec-dev libavfilter-dev libavformat-dev libavutil-dev git ssh unzip nano python3-pip && \
+git clone --recursive https://github.com/dmlc/decord && \
+cd decord && \
+find . -type f -exec sed -i "s/AVInputFormat \*/const AVInputFormat \*/g" {} \; && \
+sed -i "s/[[:space:]]AVCodec \*dec/const AVCodec \*dec/" src/video/video_reader.cc && \
+sed -i "s/avcodec\.h>/avcodec\.h>\n#include <libavcodec\/bsf\.h>/" src/video/ffmpeg/ffmpeg_common.h && \
+mkdir build && cd build && \
+scp /workspace/Video_Codec_SDK_13.0.19.zip . && \
+unzip Video_Codec_SDK_13.0.19.zip && \
+cp Video_Codec_SDK_13.0.19/Lib/linux/stubs/aarch64/* /usr/local/cuda/lib64/ && \
+cp Video_Codec_SDK_13.0.19/Interface/* /usr/local/cuda/include && \
+cmake .. -DUSE_CUDA=ON -DCMAKE_BUILD_TYPE=Release && \
+make -j 4 && \
+cd ../python && python3 setup.py install; fi
+
+RUN if [[ ${TARGETPLATFORM} == 'linux/arm64' ]]; then apt remove -y python3-blinker; fi
+# Install the dependencies from requirements-docker.txt
+COPY ./requirements-docker.txt /requirements.txt
+RUN pip install --no-cache-dir -r /requirements.txt
 RUN mkdir -p /workspace
 WORKDIR /workspace
 

--- a/cosmos_predict2/data/action_conditioned/action_conditioned_dataset.py
+++ b/cosmos_predict2/data/action_conditioned/action_conditioned_dataset.py
@@ -28,7 +28,6 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import imageio
 import numpy as np
 import torch
-from decord import VideoReader, cpu
 from einops import rearrange
 from torch.utils.data import Dataset
 from torchvision import transforms as T
@@ -198,6 +197,7 @@ class ActionConditionedDataset(Dataset):
         return len(self.samples)
 
     def _load_video(self, video_path, frame_ids):
+        from decord import VideoReader, cpu # Importing here due to malloc errors on ARM when importing on top level
         vr = VideoReader(video_path, ctx=cpu(0), num_threads=2)
         assert (np.array(frame_ids) < len(vr)).all()
         assert (np.array(frame_ids) >= 0).all()

--- a/documentations/setup.md
+++ b/documentations/setup.md
@@ -19,7 +19,7 @@ cd cosmos-predict2
 ### ARM installation
 When using an ARM platform, like GB200, special steps are required to install the `decord` package.
 You need to make sure that [NVIDIA Video Codec SDK](https://developer.nvidia.com/nvidia-video-codec-sdk/download) is downloaded in the root of the repository.
-The installation will be handled by the Conda scripts of Dockerfile.
+The installation will be handled by the Conda scripts or Dockerfile.
 ### Option 1: Conda environment
 
 Please make sure you have a Conda distribution installed ([instructions](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html)).

--- a/documentations/setup.md
+++ b/documentations/setup.md
@@ -16,6 +16,10 @@ git clone git@github.com:nvidia-cosmos/cosmos-predict2.git
 cd cosmos-predict2
 ```
 
+### ARM installation
+When using an ARM platform, like GB200, special steps are required to install the `decord` package.
+You need to make sure that [NVIDIA Video Codec SDK](https://developer.nvidia.com/nvidia-video-codec-sdk/download) is downloaded in the root of the repository.
+The installation will be handled by the Conda scripts of Dockerfile.
 ### Option 1: Conda environment
 
 Please make sure you have a Conda distribution installed ([instructions](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html)).
@@ -25,6 +29,8 @@ Please make sure you have a Conda distribution installed ([instructions](https:/
 conda env create --file cosmos-predict2.yaml
 conda activate cosmos-predict2
 
+# Try to install decord when on ARM platform
+bash scripts/install_decord_arm.sh
 # Install dependencies
 pip install -r requirements-conda.txt
 pip install flash-attn==2.6.3 --no-build-isolation

--- a/scripts/install_decord_arm.sh
+++ b/scripts/install_decord_arm.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+arch=$(uname -m)
+
+if [[ "$arch" == "aarch64" || "$arch" == "arm64" ]]; then
+  export DEBIAN_FRONTEND=noninteractive && \
+  apt-get update && \
+  apt-get install -y build-essential python3-dev python3-setuptools make cmake \
+                     ffmpeg libavcodec-dev libavfilter-dev libavformat-dev libavutil-dev git ssh unzip nano python3-pip && \
+  git clone --recursive https://github.com/dmlc/decord && \
+  cd decord && \
+  find . -type f -exec sed -i "s/AVInputFormat \*/const AVInputFormat \*/g" {} \; && \
+  sed -i "s/[[:space:]]AVCodec \*dec/const AVCodec \*dec/" src/video/video_reader.cc && \
+  sed -i "s/avcodec\.h>/avcodec\.h>\n#include <libavcodec\/bsf\.h>/" src/video/ffmpeg/ffmpeg_common.h && \
+  mkdir build && cd build && \
+  scp ../../Video_Codec_SDK_13.0.19.zip . && \
+  unzip Video_Codec_SDK_13.0.19.zip && \
+  cp Video_Codec_SDK_13.0.19/Lib/linux/stubs/aarch64/* /usr/local/cuda/lib64/ && \
+  cp Video_Codec_SDK_13.0.19/Interface/* /usr/local/cuda/include && \
+  cmake .. -DUSE_CUDA=ON -DCMAKE_BUILD_TYPE=Release && \
+  make -j 4 && \
+  cd ../python && python3 setup.py install
+fi


### PR DESCRIPTION
This PR adds the option to build the docker image and Conda environment on ARM. The main difficulty is in building the `decord` package. This PR adds necessary scripts and Dockerfile changes, as well as README updates.