### PR TITLE
refactor: Rename `data_train` to `dataloader_train`

### DIFF
--- a/cosmos_predict2/configs/action_conditioned/defaults/data.py
+++ b/cosmos_predict2/configs/action_conditioned/defaults/data.py
@@ -87,13 +87,13 @@ def register_training_and_val_data_action_conditioned():
 
     # for local dataset
     cs.store(
-        group="data_train",
+        group="dataloader_train",
         package="dataloader_train",
         name="bridge_train",
         node=bridge_train_dataloader,
     )
     cs.store(
-        group="data_val",
+        group="dataloader_val",
         package="dataloader_val",
         name="bridge_val",
         node=bridge_val_dataloader,

--- a/cosmos_predict2/configs/action_conditioned/experiment/exp.py
+++ b/cosmos_predict2/configs/action_conditioned/experiment/exp.py
@@ -25,7 +25,7 @@ action_conditioned_predict2_video2world_2b_training = dict(
         {"override /model": "action_conditioned_predict2_v2w_2b_fsdp"},
         {"override /optimizer": "fusedadamw"},
         {"override /ckpt_type": "standard"},
-        {"override /data_train": "bridge_train"},
+        {"override /dataloader_train": "bridge_train"},
         "_self_",
     ],
     model=dict(

--- a/cosmos_predict2/configs/base/config.py
+++ b/cosmos_predict2/configs/base/config.py
@@ -38,8 +38,8 @@ class Config(config.Config):
     defaults: List[Any] = attrs.field(
         factory=lambda: [
             "_self_",
-            {"data_train": None},
-            {"data_val": None},
+            {"dataloader_train": None},
+            {"dataloader_val": None},
             {"optimizer": "fusedadamw"},
             {"scheduler": "constant"},
             {"model": "predict2_video2world_fsdp_2b"},

--- a/cosmos_predict2/configs/base/defaults/data.py
+++ b/cosmos_predict2/configs/base/defaults/data.py
@@ -65,7 +65,7 @@ MOCK_DATA_VIDEO_ONLY_CONFIG = _VIDEO_LOADER
 
 def register_training_and_val_data():
     cs = ConfigStore()
-    cs.store(group="data_train", package="dataloader_train", name="mock", node=MOCK_DATA_INTERLEAVE_CONFIG)
-    cs.store(group="data_train", package="dataloader_train", name="mock_image", node=MOCK_DATA_IMAGE_ONLY_CONFIG)
-    cs.store(group="data_train", package="dataloader_train", name="mock_video", node=MOCK_DATA_VIDEO_ONLY_CONFIG)
-    cs.store(group="data_val", package="dataloader_val", name="mock", node=MOCK_DATA_INTERLEAVE_CONFIG)
+    cs.store(group="dataloader_train", package="dataloader_train", name="mock", node=MOCK_DATA_INTERLEAVE_CONFIG)
+    cs.store(group="dataloader_train", package="dataloader_train", name="mock_image", node=MOCK_DATA_IMAGE_ONLY_CONFIG)
+    cs.store(group="dataloader_train", package="dataloader_train", name="mock_video", node=MOCK_DATA_VIDEO_ONLY_CONFIG)
+    cs.store(group="dataloader_val", package="dataloader_val", name="mock", node=MOCK_DATA_INTERLEAVE_CONFIG)

--- a/cosmos_predict2/configs/base/experiment/agibot_head_center_fisheye_color.py
+++ b/cosmos_predict2/configs/base/experiment/agibot_head_center_fisheye_color.py
@@ -71,7 +71,7 @@ predict2_video2world_training_2b_agibot_head_center_fisheye_color = dict(
         {"override /optimizer": "fusedadamw"},
         {"override /scheduler": "lambdalinear"},
         {"override /ckpt_type": "standard"},
-        {"override /data_val": "mock"},
+        {"override /dataloader_val": "mock"},
         "_self_",
     ],
     job=dict(
@@ -127,7 +127,7 @@ predict2_video2world_training_14b_agibot_head_center_fisheye_color = dict(
         {"override /optimizer": "fusedadamw"},
         {"override /scheduler": "lambdalinear"},
         {"override /ckpt_type": "standard"},
-        {"override /data_val": "mock"},
+        {"override /dataloader_val": "mock"},
         "_self_",
     ],
     job=dict(

--- a/cosmos_predict2/configs/base/experiment/cosmos_nemo_assets.py
+++ b/cosmos_predict2/configs/base/experiment/cosmos_nemo_assets.py
@@ -56,7 +56,7 @@ predict2_video2world_training_2b_cosmos_nemo_assets = dict(
         {"override /optimizer": "fusedadamw"},
         {"override /scheduler": "lambdalinear"},
         {"override /ckpt_type": "standard"},
-        {"override /data_val": "mock"},
+        {"override /dataloader_val": "mock"},
         "_self_",
     ],
     job=dict(
@@ -104,7 +104,7 @@ predict2_video2world_training_14b_cosmos_nemo_assets = dict(
         {"override /optimizer": "fusedadamw"},
         {"override /scheduler": "lambdalinear"},
         {"override /ckpt_type": "standard"},
-        {"override /data_val": "mock"},
+        {"override /dataloader_val": "mock"},
         "_self_",
     ],
     job=dict(

--- a/cosmos_predict2/configs/base/experiment/groot.py
+++ b/cosmos_predict2/configs/base/experiment/groot.py
@@ -49,6 +49,12 @@ dataloader_train_gr1 = L(DataLoader)(
     pin_memory=True,
 )
 
+cs.store(
+    group="dataloader_train",
+    package="dataloader_train",
+    name="gr1",
+    node=dataloader_train_gr1,
+)
 
 # NVTE_FUSED_ATTN=0 torchrun --nproc_per_node=8 --master_port=12341 -m scripts.train --config=cosmos_predict2/configs/base/config.py -- experiment=predict2_video2world_training_2b_groot_gr1_480
 predict2_video2world_training_2b_groot_gr1_480 = dict(
@@ -56,7 +62,8 @@ predict2_video2world_training_2b_groot_gr1_480 = dict(
         {"override /model": "predict2_video2world_fsdp_2b"},
         {"override /optimizer": "fusedadamw"},
         {"override /ckpt_type": "standard"},
-        {"override /data_val": "mock"},
+        {"override /dataloader_val": "mock"},
+        {"override /dataloader_train": "gr1"},
         {"override /scheduler": "lambdalinear"},
         "_self_",
     ],
@@ -83,7 +90,6 @@ predict2_video2world_training_2b_groot_gr1_480 = dict(
     model_parallel=dict(
         context_parallel_size=1,
     ),
-    dataloader_train=dataloader_train_gr1,
     trainer=dict(
         distributed_parallelism="fsdp",
         callbacks=dict(
@@ -95,13 +101,21 @@ predict2_video2world_training_2b_groot_gr1_480 = dict(
     ),
 )
 
+# predict2_video2world_training_2b_groot_gr1_480_mock = dict(
+#     defaults=[
+#         {"/experiment/predict2_video2world_training_2b_groot_gr1_480"},
+#         "_self_",
+#     ],
+
+# )
+
 # torchrun --nproc_per_node=8 --master_port=12341 -m scripts.train --config=cosmos_predict2/configs/base/config.py -- experiment=predict2_video2world_training_14b_groot_gr1_480
 predict2_video2world_training_14b_groot_gr1_480 = dict(
     defaults=[
         {"override /model": "predict2_video2world_fsdp_14b"},
         {"override /optimizer": "fusedadamw"},
         {"override /ckpt_type": "standard"},
-        {"override /data_val": "mock"},
+        {"override /dataloader_val": "mock"},
         {"override /scheduler": "lambdalinear"},
         "_self_",
     ],

--- a/cosmos_predict2/configs/base/experiment/groot.py
+++ b/cosmos_predict2/configs/base/experiment/groot.py
@@ -101,14 +101,6 @@ predict2_video2world_training_2b_groot_gr1_480 = dict(
     ),
 )
 
-# predict2_video2world_training_2b_groot_gr1_480_mock = dict(
-#     defaults=[
-#         {"/experiment/predict2_video2world_training_2b_groot_gr1_480"},
-#         "_self_",
-#     ],
-
-# )
-
 # torchrun --nproc_per_node=8 --master_port=12341 -m scripts.train --config=cosmos_predict2/configs/base/config.py -- experiment=predict2_video2world_training_14b_groot_gr1_480
 predict2_video2world_training_14b_groot_gr1_480 = dict(
     defaults=[

--- a/documentations/post-training_video2world.md
+++ b/documentations/post-training_video2world.md
@@ -89,7 +89,7 @@ predict2_video2world_training_2b_custom_data = dict(
         {"override /optimizer": "fusedadamw"},
         {"override /scheduler": "lambdalinear"},
         {"override /ckpt_type": "standard"},
-        {"override /data_val": "mock"},
+        {"override /dataloader_val": "mock"},
         "_self_",
     ],
     job=dict(
@@ -156,7 +156,7 @@ In the above config example, it starts by overriding from the registered configs
     {"override /optimizer": "fusedadamw"},
     {"override /scheduler": "lambdalinear"},
     {"override /ckpt_type": "standard"},
-    {"override /data_val": "mock"},
+    {"override /dataloader_val": "mock"},
 ```
 
 The configuration system is organized as follows:

--- a/documentations/post-training_video2world_action.md
+++ b/documentations/post-training_video2world_action.md
@@ -64,7 +64,7 @@ action_conditioned_predict2_video2world_2b_training = dict(
         {"override /model": "action_conditioned_predict2_v2w_2b_fsdp"},
         {"override /optimizer": "fusedadamw"},
         {"override /ckpt_type": "standard"},
-        {"override /data_train": "bridge_train"},
+        {"override /dataloader_train": "bridge_train"},
         "_self_",
     ],
     model=dict(


### PR DESCRIPTION
## Changes

Since `data_train` is used to configure `dataloader_train` so renaming it to improve clarity.