### PR TITLE
Text2image post-training support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,13 @@ For inference examples and usage
   * Multi-GPU inference for faster generation
 
 For post-training customization
-* **[Post-training guide](documentations/post-training_video2world.md)**: General guide to the training system in the codebase
-* **[Post-training on Cosmos-NeMo-Assets](documentations/post-training_video2world_cosmos_nemo_assets.md)**: Case study for post-training on Cosmos-NeMo-Assets data
-* **[Post-training on fisheye-view AgiBotWorld-Alpha dataset](documentations/post-training_video2world_agibot_fisheye.md)**: Case study for post-training on fisheye-view robot videos from AgiBotWorld-Alpha dataset.
-* **[Post-training on GR00T Dreams GR1 and DROID datasets](documentations/post-training_video2world_gr00t.md)**: Case study for post-training on GR00T Dreams GR1 and DROID datasets.
-* **[Action-conditioned Post-training on Bridge dataset](documentations/post-training_video2world_action.md)**: Case study for action-conditioned post-training on Bridge dataset.
-
+* **[Video2World Post-training guide](documentations/post-training_video2world.md)**: General guide to the video2world training system in the codebase.
+* **[Video2World Post-training on Cosmos-NeMo-Assets](documentations/post-training_video2world_cosmos_nemo_assets.md)**: Case study for post-training on Cosmos-NeMo-Assets data
+* **[Video2World Post-training on fisheye-view AgiBotWorld-Alpha dataset](documentations/post-training_video2world_agibot_fisheye.md)**: Case study for post-training on fisheye-view robot videos from AgiBotWorld-Alpha dataset.
+* **[Video2World Post-training on GR00T Dreams GR1 and DROID datasets](documentations/post-training_video2world_gr00t.md)**: Case study for post-training on GR00T Dreams GR1 and DROID datasets.
+* **[Video2World Action-conditioned Post-training on Bridge dataset](documentations/post-training_video2world_action.md)**: Case study for action-conditioned post-training on Bridge dataset.
+* **[Text2Image Post-training guide](documentations/post-training_text2image.md)**: General guide to the text2image training system in the codebase.
+* **[Text2Image Post-training on Cosmos-NeMo-Assets](documentations/post-training_text2image_cosmos_nemo_assets.md)**: Case study for post-training on Cosmos-NeMo-Assets image data.
 
 Our [performance guide](documentations/performance.md) includes
 * [Hardware requirements](documentations/performance.md#hardware-requirements): Recommended GPU configurations and memory requirements

--- a/cosmos_predict2/configs/base/config_text2image.py
+++ b/cosmos_predict2/configs/base/config_text2image.py
@@ -59,7 +59,7 @@ class Text2ImagePipelineConfig:
     state_ch: int = 16
     state_t: int = 24
     text_encoder_class: str = "T5"
-    input_data_key: str = "video"
+    input_video_key: str = "video"
     input_image_key: str = "images"
     timestamps: SolverTimestampConfig = attrs.field(factory=SolverTimestampConfig)
 

--- a/cosmos_predict2/configs/base/config_text2image.py
+++ b/cosmos_predict2/configs/base/config_text2image.py
@@ -16,6 +16,7 @@
 import attrs
 
 from cosmos_predict2.conditioner import ReMapkey, TextAttr, TextConditioner
+from cosmos_predict2.configs.base.defaults.ema import EMAConfig
 from cosmos_predict2.models.text2image_dit import MiniTrainDIT
 from cosmos_predict2.tokenizers.tokenizer import TokenizerInterface
 from imaginaire.config import make_freezable
@@ -48,16 +49,19 @@ class Text2ImagePipelineConfig:
     conditioner: LazyDict
     net: LazyDict
     tokenizer: LazyDict
+    guardrail_config: CosmosGuardrailConfig
     precision: str
     rectified_flow_t_scaling_factor: float
     resize_online: bool
     resolution: str
-    timestamps: SolverTimestampConfig = attrs.field(factory=SolverTimestampConfig)
+    ema: EMAConfig
     sigma_data: float = 1.0
     state_ch: int = 16
     state_t: int = 24
     text_encoder_class: str = "T5"
-    guardrail_config: CosmosGuardrailConfig = attrs.field(factory=CosmosGuardrailConfig)
+    input_data_key: str = "video"
+    input_image_key: str = "images"
+    timestamps: SolverTimestampConfig = attrs.field(factory=SolverTimestampConfig)
 
 
 # Cosmos Predict2 Text2Image 2B
@@ -120,6 +124,7 @@ PREDICT2_TEXT2IMAGE_PIPELINE_2B = Text2ImagePipelineConfig(
     rectified_flow_t_scaling_factor=1.0,
     resize_online=True,
     resolution="1024",
+    ema=L(EMAConfig)(enabled=False),  # defaults to inference
     sigma_data=1.0,
     state_ch=16,
     state_t=24,
@@ -197,6 +202,7 @@ PREDICT2_TEXT2IMAGE_PIPELINE_14B = Text2ImagePipelineConfig(
     rectified_flow_t_scaling_factor=1.0,
     resize_online=True,
     resolution="1024",
+    ema=L(EMAConfig)(enabled=False),  # defaults to inference
     sigma_data=1.0,
     state_ch=16,
     state_t=24,

--- a/cosmos_predict2/configs/base/config_text2image.py
+++ b/cosmos_predict2/configs/base/config_text2image.py
@@ -79,6 +79,7 @@ PREDICT2_TEXT2IMAGE_NET_2B = L(MiniTrainDIT)(
     num_blocks=28,
     num_heads=16,
     mlp_ratio=4.0,
+    atten_backend="minimal_a2a",
     # cross attention settings
     crossattn_emb_channels=1024,
     # positional embedding settings

--- a/cosmos_predict2/configs/base/config_video2world.py
+++ b/cosmos_predict2/configs/base/config_video2world.py
@@ -75,7 +75,7 @@ class Video2WorldPipelineConfig:
     state_ch: int = 16
     state_t: int = 24
     text_encoder_class: str = "T5"
-    input_data_key: str = "video"
+    input_video_key: str = "video"
     input_image_key: str = "images"
     timestamps: SolverTimestampConfig = attrs.field(factory=SolverTimestampConfig)
 

--- a/cosmos_predict2/configs/base/config_video2world.py
+++ b/cosmos_predict2/configs/base/config_video2world.py
@@ -18,7 +18,16 @@ from enum import Enum
 
 import attrs
 
-from cosmos_predict2.conditioner import BooleanFlag, ReMapkey, TextAttr, VideoConditioner
+from cosmos_predict2.conditioner import (
+    BooleanFlag,
+    ReMapkey,
+    TextAttr,
+    VideoConditioner,
+)
+from cosmos_predict2.configs.base.config_text2image import (
+    CosmosGuardrailConfig,
+    SolverTimestampConfig,
+)
 from cosmos_predict2.configs.base.defaults.ema import EMAConfig
 from cosmos_predict2.models.text2image_dit import SACConfig
 from cosmos_predict2.models.video2world_dit import MinimalV1LVGDiT
@@ -38,25 +47,7 @@ class ConditioningStrategy(str, Enum):
 
 @make_freezable
 @attrs.define(slots=False)
-class SolverTimestampConfig:
-    nfe: int = 35
-    t_min: float = 0.002
-    t_max: float = 80.0
-    order: float = 7.0
-    is_forward: bool = False  # whether generate forward or backward timestamps
-
-
-@make_freezable
-@attrs.define(slots=False)
 class CosmosReason1Config:
-    checkpoint_dir: str
-    offload_model_to_cpu: bool = True
-    enabled: bool = True
-
-
-@make_freezable
-@attrs.define(slots=False)
-class CosmosGuardrailConfig:
     checkpoint_dir: str
     offload_model_to_cpu: bool = True
     enabled: bool = True

--- a/cosmos_predict2/configs/base/defaults/data.py
+++ b/cosmos_predict2/configs/base/defaults/data.py
@@ -69,3 +69,5 @@ def register_training_and_val_data():
     cs.store(group="dataloader_train", package="dataloader_train", name="mock_image", node=MOCK_DATA_IMAGE_ONLY_CONFIG)
     cs.store(group="dataloader_train", package="dataloader_train", name="mock_video", node=MOCK_DATA_VIDEO_ONLY_CONFIG)
     cs.store(group="dataloader_val", package="dataloader_val", name="mock", node=MOCK_DATA_INTERLEAVE_CONFIG)
+    cs.store(group="dataloader_val", package="dataloader_val", name="mock_image", node=MOCK_DATA_IMAGE_ONLY_CONFIG)
+    cs.store(group="dataloader_val", package="dataloader_val", name="mock_video", node=MOCK_DATA_VIDEO_ONLY_CONFIG)

--- a/cosmos_predict2/configs/base/defaults/data.py
+++ b/cosmos_predict2/configs/base/defaults/data.py
@@ -22,7 +22,7 @@ from imaginaire.lazy_config import LazyCall as L
 
 _IMAGE_LOADER = L(get_cached_replay_dataloader)(
     dataset=L(get_image_dataset)(
-        resolution="512",
+        resolution="480",
     ),
     batch_size=2,
     shuffle=False,
@@ -34,7 +34,7 @@ _IMAGE_LOADER = L(get_cached_replay_dataloader)(
 
 _VIDEO_LOADER = L(get_cached_replay_dataloader)(
     dataset=L(get_video_dataset)(
-        resolution="512",
+        resolution="480",
         num_video_frames=93,  # number of pixel frames, the number needs to agree with tokenizer encoder since tokenizer can not handle arbitrary length
     ),
     batch_size=1,

--- a/cosmos_predict2/configs/base/defaults/model.py
+++ b/cosmos_predict2/configs/base/defaults/model.py
@@ -72,7 +72,7 @@ PREDICT2_TEXT2IMAGE_FSDP_14B = dict(
                 dit_path="checkpoints/nvidia/Cosmos-Predict2-14B-Text2Image/model.pt",
                 text_encoder_path="",  # Do not load text encoder for training.
             ),
-            fsdp_shard_size=4,
+            fsdp_shard_size=8,
         ),
         _recursive_=False,
     ),

--- a/cosmos_predict2/configs/base/defaults/model.py
+++ b/cosmos_predict2/configs/base/defaults/model.py
@@ -15,6 +15,10 @@
 
 from hydra.core.config_store import ConfigStore
 
+from cosmos_predict2.configs.base.config_text2image import (
+    PREDICT2_TEXT2IMAGE_PIPELINE_2B,
+    PREDICT2_TEXT2IMAGE_PIPELINE_14B,
+)
 from cosmos_predict2.configs.base.config_video2world import PREDICT2_VIDEO2WORLD_PIPELINE_2B  # 720p, 16fps
 from cosmos_predict2.configs.base.config_video2world import PREDICT2_VIDEO2WORLD_PIPELINE_14B  # 720p, 16fps
 from cosmos_predict2.configs.base.config_video2world import (
@@ -27,12 +31,52 @@ from cosmos_predict2.configs.base.config_video2world import (
     PREDICT2_VIDEO2WORLD_PIPELINE_14B_720P_10FPS,
     PREDICT2_VIDEO2WORLD_PIPELINE_14B_720P_16FPS,
 )
+from cosmos_predict2.models.text2image_model import (
+    Predict2Text2ImageModel,
+    Predict2Text2ImageModelConfig,
+)
 from cosmos_predict2.models.video2world_model import (
     Predict2ModelManagerConfig,
     Predict2Video2WorldModel,
     Predict2Video2WorldModelConfig,
 )
 from imaginaire.lazy_config import LazyCall as L
+
+# 2b model config for predict2 text2image
+PREDICT2_TEXT2IMAGE_FSDP_2B = dict(
+    trainer=dict(
+        distributed_parallelism="fsdp",
+    ),
+    model=L(Predict2Text2ImageModel)(
+        config=Predict2Text2ImageModelConfig(
+            pipe_config=PREDICT2_TEXT2IMAGE_PIPELINE_2B,
+            model_manager_config=L(Predict2ModelManagerConfig)(
+                dit_path="checkpoints/nvidia/Cosmos-Predict2-2B-Text2Image/model.pt",
+                text_encoder_path="",  # Do not load text encoder for training.
+            ),
+            fsdp_shard_size=1,
+        ),
+        _recursive_=False,
+    ),
+)
+
+# 14b model config for predict2 text2image
+PREDICT2_TEXT2IMAGE_FSDP_14B = dict(
+    trainer=dict(
+        distributed_parallelism="fsdp",
+    ),
+    model=L(Predict2Text2ImageModel)(
+        config=Predict2Text2ImageModelConfig(
+            pipe_config=PREDICT2_TEXT2IMAGE_PIPELINE_14B,
+            model_manager_config=L(Predict2ModelManagerConfig)(
+                dit_path="checkpoints/nvidia/Cosmos-Predict2-14B-Text2Image/model.pt",
+                text_encoder_path="",  # Do not load text encoder for training.
+            ),
+            fsdp_shard_size=4,
+        ),
+        _recursive_=False,
+    ),
+)
 
 # default 2b model config for predict2 video2world (720p, 16fps)
 PREDICT2_VIDEO2WORLD_FSDP_2B = dict(
@@ -221,6 +265,10 @@ PREDICT2_VIDEO2WORLD_FSDP_14B_720P_16FPS = dict(
 
 def register_model() -> None:
     cs = ConfigStore.instance()
+    # predict2 t2i 2b model
+    cs.store(group="model", package="_global_", name="predict2_text2image_fsdp_2b", node=PREDICT2_TEXT2IMAGE_FSDP_2B)
+    # predict2 t2i 14b model
+    cs.store(group="model", package="_global_", name="predict2_text2image_fsdp_14b", node=PREDICT2_TEXT2IMAGE_FSDP_14B)
     # predict2 v2w 2b model (default 720p, 16fps)
     cs.store(group="model", package="_global_", name="predict2_video2world_fsdp_2b", node=PREDICT2_VIDEO2WORLD_FSDP_2B)
     # predict2 v2w 14b model (default 720p, 16fps)

--- a/cosmos_predict2/configs/base/experiment/agibot_head_center_fisheye_color.py
+++ b/cosmos_predict2/configs/base/experiment/agibot_head_center_fisheye_color.py
@@ -141,6 +141,7 @@ predict2_video2world_training_2b_agibot_head_center_fisheye_color = dict(
         config=dict(
             pipe_config=dict(
                 ema=dict(enabled=True),
+                prompt_refiner_config=dict(enabled=False),
                 guardrail_config=dict(enabled=False),
                 max_num_conditional_frames=1,
                 min_num_conditional_frames=1,
@@ -268,6 +269,7 @@ predict2_video2world_training_14b_agibot_head_center_fisheye_color = dict(
         config=dict(
             pipe_config=dict(
                 ema=dict(enabled=True),
+                prompt_refiner_config=dict(enabled=False),
                 guardrail_config=dict(enabled=False),
                 max_num_conditional_frames=1,
                 min_num_conditional_frames=1,

--- a/cosmos_predict2/configs/base/experiment/agibot_head_center_fisheye_color.py
+++ b/cosmos_predict2/configs/base/experiment/agibot_head_center_fisheye_color.py
@@ -175,7 +175,7 @@ predict2_video2world_training_2b_agibot_head_center_fisheye_color = dict(
         warm_up_steps=[2_000],
         cycle_lengths=[400_000],
         f_max=[0.99],
-        f_min=[0.4],
+        f_min=[0.0],
     ),
 )
 
@@ -299,7 +299,7 @@ predict2_video2world_training_14b_agibot_head_center_fisheye_color = dict(
         warm_up_steps=[2_000],
         cycle_lengths=[50_000],
         f_max=[0.2],
-        f_min=[0.1],
+        f_min=[0.0],
     ),
 )
 

--- a/cosmos_predict2/configs/base/experiment/cosmos_nemo_assets.py
+++ b/cosmos_predict2/configs/base/experiment/cosmos_nemo_assets.py
@@ -91,7 +91,7 @@ predict2_text2image_training_2b_cosmos_nemo_assets = dict(
     ),
     scheduler=dict(
         warm_up_steps=[0],
-        cycle_lengths=[100_000],
+        cycle_lengths=[1_000],
         f_max=[0.17],
         f_min=[0.0],
     ),
@@ -139,8 +139,8 @@ predict2_text2image_training_14b_cosmos_nemo_assets = dict(
         weight_decay=0.2,
     ),
     scheduler=dict(
-        warm_up_steps=[2_000],
-        cycle_lengths=[400_000],
+        warm_up_steps=[0],
+        cycle_lengths=[1_000],
         f_max=[0.4],
         f_min=[0.0],
     ),
@@ -204,8 +204,8 @@ predict2_video2world_training_2b_cosmos_nemo_assets = dict(
         lr=2 ** (-14.5),
     ),
     scheduler=dict(
-        warm_up_steps=[2_000],
-        cycle_lengths=[400_000],
+        warm_up_steps=[0],
+        cycle_lengths=[1_000],
         f_max=[0.6],
         f_min=[0.0],
     ),
@@ -254,8 +254,8 @@ predict2_video2world_training_14b_cosmos_nemo_assets = dict(
         weight_decay=0.2,
     ),
     scheduler=dict(
-        warm_up_steps=[2_000],
-        cycle_lengths=[40_000],
+        warm_up_steps=[0],
+        cycle_lengths=[1_000],
         f_max=[0.25],
         f_min=[0.0],
     ),

--- a/cosmos_predict2/configs/base/experiment/cosmos_nemo_assets.py
+++ b/cosmos_predict2/configs/base/experiment/cosmos_nemo_assets.py
@@ -93,7 +93,7 @@ predict2_text2image_training_2b_cosmos_nemo_assets = dict(
         warm_up_steps=[0],
         cycle_lengths=[100_000],
         f_max=[0.17],
-        f_min=[0.1],
+        f_min=[0.0],
     ),
 )
 
@@ -142,7 +142,7 @@ predict2_text2image_training_14b_cosmos_nemo_assets = dict(
         warm_up_steps=[2_000],
         cycle_lengths=[400_000],
         f_max=[0.4],
-        f_min=[0.1],
+        f_min=[0.0],
     ),
 )
 
@@ -207,7 +207,7 @@ predict2_video2world_training_2b_cosmos_nemo_assets = dict(
         warm_up_steps=[2_000],
         cycle_lengths=[400_000],
         f_max=[0.6],
-        f_min=[0.3],
+        f_min=[0.0],
     ),
 )
 
@@ -257,7 +257,7 @@ predict2_video2world_training_14b_cosmos_nemo_assets = dict(
         warm_up_steps=[2_000],
         cycle_lengths=[40_000],
         f_max=[0.25],
-        f_min=[0.1],
+        f_min=[0.0],
     ),
 )
 

--- a/cosmos_predict2/configs/base/experiment/cosmos_nemo_assets.py
+++ b/cosmos_predict2/configs/base/experiment/cosmos_nemo_assets.py
@@ -36,7 +36,7 @@ cs = ConfigStore.instance()
 
 # Cosmos-NeMo-Assets text2image example
 example_image_dataset_cosmos_nemo_assets_images = L(ImageDataset)(
-    dataset_dir="datasets/benchmark_train/cosmos_nemo_assets_images",
+    dataset_dir="datasets/cosmos_nemo_assets_images",
     image_size=(768, 1360),  # 1024 resolution, 16:9 aspect ratio
 )
 
@@ -148,7 +148,7 @@ predict2_text2image_training_14b_cosmos_nemo_assets = dict(
 
 # Cosmos-NeMo-Assets video2world example
 example_video_dataset_cosmos_nemo_assets = L(Dataset)(
-    dataset_dir="datasets/benchmark_train/cosmos_nemo_assets",
+    dataset_dir="datasets/cosmos_nemo_assets",
     num_frames=93,
     video_size=(704, 1280),
 )

--- a/cosmos_predict2/configs/base/experiment/cosmos_nemo_assets.py
+++ b/cosmos_predict2/configs/base/experiment/cosmos_nemo_assets.py
@@ -37,7 +37,7 @@ cs = ConfigStore.instance()
 # Cosmos-NeMo-Assets text2image example
 example_image_dataset_cosmos_nemo_assets_images = L(ImageDataset)(
     dataset_dir="datasets/benchmark_train/cosmos_nemo_assets_images",
-    image_size=(704, 1280),
+    image_size=(768, 1360),  # 1024 resolution, 16:9 aspect ratio
 )
 
 dataloader_train_cosmos_nemo_assets_images = L(DataLoader)(
@@ -87,13 +87,13 @@ predict2_text2image_training_2b_cosmos_nemo_assets = dict(
         save_iter=500,
     ),
     optimizer=dict(
-        lr=2 ** (-14.5),
+        lr=2 ** (-15),
     ),
     scheduler=dict(
-        warm_up_steps=[2_000],
-        cycle_lengths=[400_000],
-        f_max=[0.6],
-        f_min=[0.3],
+        warm_up_steps=[0],
+        cycle_lengths=[100_000],
+        f_max=[0.17],
+        f_min=[0.1],
     ),
 )
 
@@ -121,7 +121,7 @@ predict2_text2image_training_14b_cosmos_nemo_assets = dict(
         )
     ),
     model_parallel=dict(
-        context_parallel_size=8,
+        context_parallel_size=1,
     ),
     dataloader_train=dataloader_train_cosmos_nemo_assets_images,
     trainer=dict(
@@ -136,12 +136,13 @@ predict2_text2image_training_14b_cosmos_nemo_assets = dict(
     ),
     optimizer=dict(
         lr=2 ** (-14.5),
+        weight_decay=0.2,
     ),
     scheduler=dict(
         warm_up_steps=[2_000],
         cycle_lengths=[400_000],
-        f_max=[0.6],
-        f_min=[0.3],
+        f_max=[0.4],
+        f_min=[0.1],
     ),
 )
 

--- a/cosmos_predict2/data/dataset_image.py
+++ b/cosmos_predict2/data/dataset_image.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import pickle
+import traceback
+import warnings
+
+import imageio
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+from torchvision import transforms as T
+
+from cosmos_predict2.data.dataset_utils import (
+    Resize_Preprocess,
+    ToTensorImage,
+)
+from imaginaire.utils import log
+
+"""
+Test the dataset with the following command:
+python -m cosmos_predict2.data.dataset_image
+"""
+
+
+class ImageDataset(Dataset):
+    def __init__(self, dataset_dir: str, image_size: list):
+        """Dataset class for loading text-to-image generation data.
+
+        Args:
+            dataset_dir (str): Base path to the dataset directory
+            image_size (list): Target size [H,W] for video frames
+
+        Returns dict with:
+            - image: RGB frames tensor [C,H,W]
+        """
+
+        super().__init__()
+        self.dataset_dir = dataset_dir
+
+        image_dir = os.path.join(self.dataset_dir, "images")
+        self.t5_dir = os.path.join(self.dataset_dir, "t5_xxl")
+
+        self.image_paths = [os.path.join(image_dir, f) for f in os.listdir(image_dir) if f.endswith(".jpg")]
+        self.image_paths = sorted(self.image_paths)
+
+        # remove video paths that does not have t5_embedding
+        self.image_paths = [
+            path
+            for path in self.image_paths
+            if os.path.exists(os.path.join(self.t5_dir, os.path.basename(path).replace(".jpg", ".pickle")))
+        ]
+        log.info(f"{len(self.image_paths)} images in total")
+
+        self.wrong_number = 0
+        self.preprocess = T.Compose([ToTensorImage(), Resize_Preprocess(tuple(image_size))])
+
+    def __str__(self) -> str:
+        return f"{len(self.image_paths)} samples from {self.dataset_dir}"
+
+    def __len__(self) -> int:
+        return len(self.image_paths)
+
+    def _get_image(self, image_path) -> torch.Tensor:
+        image = imageio.v3.imread(image_path)
+        image = torch.from_numpy(image).permute(2, 0, 1)  # (c, h, w)
+        image = self.preprocess(image)
+        image = torch.clamp(image * 255.0, 0, 255).to(torch.uint8)
+
+        return image
+
+    def __getitem__(self, index):
+        try:
+            data = dict()
+            image = self._get_image(self.image_paths[index])
+            image_path = self.image_paths[index]
+            t5_embedding_path = os.path.join(
+                self.t5_dir,
+                os.path.basename(image_path).replace(".jpg", ".pickle"),
+            )
+
+            data["images"] = image  # .unsqueeze(0)  # Add batch dimension
+            with open(t5_embedding_path, "rb") as f:
+                t5_embedding = pickle.load(f)[0]  # [n_tokens, 1024]
+            n_tokens = t5_embedding.shape[0]
+            if n_tokens < 512:
+                t5_embedding = np.concatenate(
+                    [t5_embedding, np.zeros((512 - n_tokens, 1024), dtype=np.float32)], axis=0
+                )
+            t5_text_mask = torch.zeros(512, dtype=torch.int64)
+            t5_text_mask[:n_tokens] = 1
+
+            data["t5_text_embeddings"] = torch.from_numpy(t5_embedding)
+            data["t5_text_mask"] = t5_text_mask
+            data["fps"] = torch.zeros(1, dtype=torch.float)  # No FPS for images
+            data["image_size"] = torch.tensor([704, 1280, 704, 1280])
+            data["num_frames"] = torch.ones(1)
+            data["padding_mask"] = torch.zeros(1, 704, 1280)
+
+            return data
+        except Exception:
+            warnings.warn(
+                f"Invalid data encountered: {self.image_paths[index]}. Skipped "
+                f"(by randomly sampling another sample in the same dataset)."
+            )
+            warnings.warn("FULL TRACEBACK:")
+            warnings.warn(traceback.format_exc())
+            self.wrong_number += 1
+            log.info(self.wrong_number, rank0_only=False)
+            return self[np.random.randint(len(self.samples))]
+
+
+if __name__ == "__main__":
+    dataset = ImageDataset(
+        dataset_dir="datasets/benchmark_train/cosmos_nemo_assets_images",
+        image_size=[480, 832],
+    )
+
+    indices = [0, 13, -1]
+    for idx in indices:
+        data = dataset[idx]
+        log.info(
+            (
+                f"{idx=} "
+                f"{data['images'].sum()=}\n"
+                f"{data['images'].shape=}\n"
+                f"{data['t5_text_embeddings'].shape=}\n"
+                "---"
+            )
+        )

--- a/cosmos_predict2/data/dataset_image.py
+++ b/cosmos_predict2/data/dataset_image.py
@@ -25,6 +25,8 @@ from torch.utils.data import Dataset
 from torchvision import transforms as T
 
 from cosmos_predict2.data.dataset_utils import (
+    _NUM_T5_TOKENS,
+    _T5_EMBED_DIM,
     Resize_Preprocess,
     ToTensorImage,
 )
@@ -96,13 +98,13 @@ class ImageDataset(Dataset):
 
             data["images"] = image
             with open(t5_embedding_path, "rb") as f:
-                t5_embedding = pickle.load(f)[0]  # [n_tokens, 1024]
+                t5_embedding = pickle.load(f)[0]  # [n_tokens, _T5_EMBED_DIM]
             n_tokens = t5_embedding.shape[0]
-            if n_tokens < 512:
+            if n_tokens < _NUM_T5_TOKENS:
                 t5_embedding = np.concatenate(
-                    [t5_embedding, np.zeros((512 - n_tokens, 1024), dtype=np.float32)], axis=0
+                    [t5_embedding, np.zeros((_NUM_T5_TOKENS - n_tokens, _T5_EMBED_DIM), dtype=np.float32)], axis=0
                 )
-            t5_text_mask = torch.zeros(512, dtype=torch.int64)
+            t5_text_mask = torch.zeros(_NUM_T5_TOKENS, dtype=torch.int64)
             t5_text_mask[:n_tokens] = 1
 
             data["t5_text_embeddings"] = torch.from_numpy(t5_embedding)

--- a/cosmos_predict2/data/dataset_image.py
+++ b/cosmos_predict2/data/dataset_image.py
@@ -78,7 +78,7 @@ class ImageDataset(Dataset):
         image = imageio.v3.imread(image_path)
         image = torch.from_numpy(image).permute(2, 0, 1)  # (c, h, w)
         image = self.preprocess(image)
-        image = torch.clamp(image * 255.0, 0, 255).to(torch.uint8)
+        image = torch.clamp(image, 0.0, 1.0).sub_(0.5).div_(0.5)  # Normalize to [-1, 1]
 
         return image
 

--- a/cosmos_predict2/data/dataset_image.py
+++ b/cosmos_predict2/data/dataset_image.py
@@ -92,7 +92,9 @@ class ImageDataset(Dataset):
                 os.path.basename(image_path).replace(".jpg", ".pickle"),
             )
 
-            data["images"] = image  # .unsqueeze(0)  # Add batch dimension
+            _, h, w = image.shape
+
+            data["images"] = image
             with open(t5_embedding_path, "rb") as f:
                 t5_embedding = pickle.load(f)[0]  # [n_tokens, 1024]
             n_tokens = t5_embedding.shape[0]
@@ -105,10 +107,10 @@ class ImageDataset(Dataset):
 
             data["t5_text_embeddings"] = torch.from_numpy(t5_embedding)
             data["t5_text_mask"] = t5_text_mask
-            data["fps"] = torch.zeros(1, dtype=torch.float)  # No FPS for images
-            data["image_size"] = torch.tensor([704, 1280, 704, 1280])
+            data["fps"] = torch.ones(1, dtype=torch.float) * 16  # Dummy FPS for images
+            data["image_size"] = torch.tensor([h, w, h, w])
             data["num_frames"] = torch.ones(1)
-            data["padding_mask"] = torch.zeros(1, 704, 1280)
+            data["padding_mask"] = torch.zeros(1, h, w)
 
             return data
         except Exception:
@@ -125,7 +127,7 @@ class ImageDataset(Dataset):
 
 if __name__ == "__main__":
     dataset = ImageDataset(
-        dataset_dir="datasets/benchmark_train/cosmos_nemo_assets_images",
+        dataset_dir="datasets/cosmos_nemo_assets_images",
         image_size=[480, 832],
     )
 

--- a/cosmos_predict2/data/dataset_utils.py
+++ b/cosmos_predict2/data/dataset_utils.py
@@ -55,14 +55,14 @@ class ToTensorImage:
     def __init__(self):
         pass
 
-    def __call__(self, clip):
+    def __call__(self, image):
         """
         Args:
-            clip (torch.tensor, dtype=torch.uint8): Size is (T, C, H, W)
+            image (torch.tensor, dtype=torch.uint8): Size is (C, H, W)
         Return:
-            clip (torch.tensor, dtype=torch.float): Size is (T, C, H, W)
+            image (torch.tensor, dtype=torch.float): Size is (C, H, W)
         """
-        return to_tensor_image(clip)
+        return to_tensor_image(image)
 
     def __repr__(self) -> str:
         return self.__class__.__name__

--- a/cosmos_predict2/data/dataset_utils.py
+++ b/cosmos_predict2/data/dataset_utils.py
@@ -18,6 +18,9 @@ from typing import Tuple
 import torch
 import torchvision.transforms.functional as F
 
+_T5_EMBED_DIM = 1024  # T5-XXL embedding dimension, to be imported by dataloaders
+_NUM_T5_TOKENS = 512  # Number of T5 tokens, to be imported by dataloaders
+
 
 class Resize_Preprocess:
     def __init__(self, size: Tuple[int, int]):

--- a/cosmos_predict2/data/dataset_utils.py
+++ b/cosmos_predict2/data/dataset_utils.py
@@ -13,12 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Tuple
+
 import torch
 import torchvision.transforms.functional as F
 
 
 class Resize_Preprocess:
-    def __init__(self, size: Tuple):
+    def __init__(self, size: Tuple[int, int]):
         """
         Initialize the preprocessing class with the target size.
         Args:

--- a/cosmos_predict2/data/dataset_video.py
+++ b/cosmos_predict2/data/dataset_video.py
@@ -25,7 +25,12 @@ from torch.utils.data import Dataset
 from torchvision import transforms as T
 from torchvision.transforms.v2 import UniformTemporalSubsample
 
-from cosmos_predict2.data.dataset_utils import Resize_Preprocess, ToTensorVideo
+from cosmos_predict2.data.dataset_utils import (
+    _NUM_T5_TOKENS,
+    _T5_EMBED_DIM,
+    Resize_Preprocess,
+    ToTensorVideo,
+)
 from imaginaire.utils import log
 
 """
@@ -120,13 +125,13 @@ class Dataset(Dataset):
             # Just add these to fit the interface
             # t5_embedding = np.load(sample["t5_embedding_path"])[0]
             with open(t5_embedding_path, "rb") as f:
-                t5_embedding = pickle.load(f)[0]  # [n_tokens, 1024]
+                t5_embedding = pickle.load(f)[0]  # [n_tokens, _T5_EMBED_DIM]
             n_tokens = t5_embedding.shape[0]
-            if n_tokens < 512:
+            if n_tokens < _NUM_T5_TOKENS:
                 t5_embedding = np.concatenate(
-                    [t5_embedding, np.zeros((512 - n_tokens, 1024), dtype=np.float32)], axis=0
+                    [t5_embedding, np.zeros((_NUM_T5_TOKENS - n_tokens, _T5_EMBED_DIM), dtype=np.float32)], axis=0
                 )
-            t5_text_mask = torch.zeros(512, dtype=torch.int64)
+            t5_text_mask = torch.zeros(_NUM_T5_TOKENS, dtype=torch.int64)
             t5_text_mask[:n_tokens] = 1
 
             data["t5_text_embeddings"] = torch.from_numpy(t5_embedding)

--- a/cosmos_predict2/data/dataset_video.py
+++ b/cosmos_predict2/data/dataset_video.py
@@ -113,8 +113,9 @@ class Dataset(Dataset):
             data["video_name"] = {
                 "video_path": video_path,
                 "t5_embedding_path": t5_embedding_path,
-                # "start_frame_id": '0',
             }
+
+            _, _, h, w = video.shape
 
             # Just add these to fit the interface
             # t5_embedding = np.load(sample["t5_embedding_path"])[0]
@@ -131,9 +132,9 @@ class Dataset(Dataset):
             data["t5_text_embeddings"] = torch.from_numpy(t5_embedding)
             data["t5_text_mask"] = t5_text_mask
             data["fps"] = fps
-            data["image_size"] = torch.tensor([704, 1280, 704, 1280])
+            data["image_size"] = torch.tensor([h, w, h, w])
             data["num_frames"] = self.sequence_length
-            data["padding_mask"] = torch.zeros(1, 704, 1280)
+            data["padding_mask"] = torch.zeros(1, h, w)
 
             return data
         except Exception:

--- a/cosmos_predict2/datasets/data_sources/mock_data.py
+++ b/cosmos_predict2/datasets/data_sources/mock_data.py
@@ -26,7 +26,7 @@ from imaginaire.datasets.mock_dataset import CombinedDictDataset, LambdaDataset
 
 
 def get_image_dataset(
-    resolution: str = "512",
+    resolution: str = "480",
     len_t5: int = 512,
     t5_dim: int = 1024,
     **kwargs,
@@ -52,7 +52,7 @@ def get_image_dataset(
 
 def get_video_dataset(
     num_video_frames: int,
-    resolution: str = "512",
+    resolution: str = "480",
     len_t5: int = 512,
     t5_dim: int = 1024,
     **kwargs,

--- a/cosmos_predict2/models/text2image_model.py
+++ b/cosmos_predict2/models/text2image_model.py
@@ -1,0 +1,466 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import collections
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+import attrs
+import torch
+from einops import rearrange
+from megatron.core import parallel_state
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import DTensor
+from torch.nn.modules.module import _IncompatibleKeys
+
+from cosmos_predict2.conditioner import T2VCondition
+from cosmos_predict2.configs.base.config_text2image import (
+    PREDICT2_TEXT2IMAGE_PIPELINE_2B,
+    Text2ImagePipelineConfig,
+)
+from cosmos_predict2.networks.model_weights_stats import WeightTrainingStat
+from cosmos_predict2.pipelines.text2image import Text2ImagePipeline
+from cosmos_predict2.utils.checkpointer import non_strict_load_model
+from cosmos_predict2.utils.optim_instantiate import get_base_scheduler
+from cosmos_predict2.utils.torch_future import clip_grad_norm_
+from imaginaire.lazy_config import LazyDict, instantiate
+from imaginaire.model import ImaginaireModel
+from imaginaire.utils import log
+
+
+@attrs.define(slots=False)
+class Predict2ModelManagerConfig:
+    # Local path, use it in fast debug run
+    dit_path: str = "checkpoints/nvidia/Cosmos-Predict2-2B-Text2Image/model.pt"
+    # For inference
+    text_encoder_path: str = ""  # not used in training.
+
+
+@attrs.define(slots=False)
+class Predict2Text2ImageModelConfig:
+    train_architecture: str = "base"
+    lora_rank: int = 16
+    lora_alpha: int = 16
+    lora_target_modules: str = "q_proj,k_proj,v_proj,output_proj,mlp.layer1,mlp.layer2"
+    init_lora_weights: bool = True
+
+    precision: str = "bfloat16"
+    input_data_key: str = "video"
+    input_image_key: str = "images"
+    loss_reduce: str = "mean"
+    loss_scale: float = 10.0
+
+    # This is used for the original way to load models
+    model_manager_config: Predict2ModelManagerConfig = Predict2ModelManagerConfig()
+    # This is a new way to load models
+    pipe_config: Text2ImagePipelineConfig = PREDICT2_TEXT2IMAGE_PIPELINE_2B
+    # debug flag
+    debug_without_randomness: bool = False
+    fsdp_shard_size: int = 0  # 0 means not using fsdp, -1 means set to world size
+
+
+class Predict2Text2ImageModel(ImaginaireModel):
+    def __init__(self, config: Predict2Text2ImageModelConfig):
+        super().__init__()
+
+        self.config = config
+
+        self.precision = {
+            "float32": torch.float32,
+            "float16": torch.float16,
+            "bfloat16": torch.bfloat16,
+        }[config.precision]
+        self.tensor_kwargs = {"device": "cuda", "dtype": self.precision}
+        self.device = torch.device("cuda")
+
+        # 1. set data keys and data information
+        self.setup_data_key()
+
+        # 4. Set up loss options, including loss masking, loss reduce and loss scaling
+        self.loss_reduce = getattr(config, "loss_reduce", "mean")
+        assert self.loss_reduce in ["mean", "sum"]
+        self.loss_scale = getattr(config, "loss_scale", 1.0)
+        log.critical(f"Using {self.loss_reduce} loss reduce with loss scale {self.loss_scale}")
+
+        # 7. training states
+        if parallel_state.is_initialized():
+            self.data_parallel_size = parallel_state.get_data_parallel_world_size()
+        else:
+            self.data_parallel_size = 1
+
+        # New way to init pipe
+        self.pipe = Text2ImagePipeline.from_config(
+            config.pipe_config,
+            dit_path=config.model_manager_config.dit_path,
+        )
+
+        self.freeze_parameters()
+        if config.train_architecture == "lora":
+            self.add_lora_to_model(
+                self.pipe.dit,
+                lora_rank=config.lora_rank,
+                lora_alpha=config.lora_alpha,
+                lora_target_modules=config.lora_target_modules,
+                init_lora_weights=config.init_lora_weights,
+            )
+            if self.pipe.dit_ema:
+                self.add_lora_to_model(
+                    self.pipe.dit_ema,
+                    lora_rank=config.lora_rank,
+                    lora_alpha=config.lora_alpha,
+                    lora_target_modules=config.lora_target_modules,
+                    init_lora_weights=config.init_lora_weights,
+                )
+        else:
+            self.pipe.denoising_model().requires_grad_(True)
+        total_params = sum(p.numel() for p in self.parameters())
+        frozen_params = sum(p.numel() for p in self.parameters() if not p.requires_grad)
+        trainable_params = sum(p.numel() for p in self.parameters() if p.requires_grad)
+        # Print the number in billions, or in the format of 1,000,000,000
+        log.info(
+            f"Total parameters: {total_params / 1e9:.2f}B, Frozen parameters: {frozen_params:,}, Trainable parameters: {trainable_params:,}"
+        )
+
+        if config.fsdp_shard_size != 0 and torch.distributed.is_initialized():
+            if config.fsdp_shard_size == -1:
+                fsdp_shard_size = torch.distributed.get_world_size()
+                replica_group_size = 1
+            else:
+                fsdp_shard_size = min(config.fsdp_shard_size, torch.distributed.get_world_size())
+                replica_group_size = torch.distributed.get_world_size() // fsdp_shard_size
+            dp_mesh = init_device_mesh(
+                "cuda", (replica_group_size, fsdp_shard_size), mesh_dim_names=("replicate", "shard")
+            )
+            log.info(f"Using FSDP with shard size {fsdp_shard_size} | device mesh: {dp_mesh}")
+            self.pipe.apply_fsdp(dp_mesh)
+        else:
+            log.info("FSDP (Fully Sharded Data Parallel) is disabled.")
+
+    # New function, added for i4 adaption
+    @property
+    def net(self) -> torch.nn.Module:
+        return self.pipe.dit
+
+    # New function, added for i4 adaption
+    @property
+    def net_ema(self) -> torch.nn.Module:
+        return self.pipe.dit_ema
+
+    # New function, added for i4 adaption
+    def init_optimizer_scheduler(
+        self, optimizer_config: LazyDict, scheduler_config: LazyDict
+    ) -> tuple[torch.optim.Optimizer, torch.optim.lr_scheduler.LRScheduler]:
+        """Creates the optimizer and scheduler for the model.
+
+        Args:
+            config_model (ModelConfig): The config object for the model.
+
+        Returns:
+            optimizer (torch.optim.Optimizer): The model optimizer.
+            scheduler (torch.optim.lr_scheduler.LRScheduler): The optimization scheduler.
+        """
+        optimizer = instantiate(optimizer_config, model=self.net)
+        scheduler = get_base_scheduler(optimizer, self, scheduler_config)
+        return optimizer, scheduler
+
+    # ------------------------ training hooks ------------------------
+    def on_before_zero_grad(
+        self, optimizer: torch.optim.Optimizer, scheduler: torch.optim.lr_scheduler.LRScheduler, iteration: int
+    ) -> None:
+        """
+        update the net_ema
+        """
+        del scheduler, optimizer
+
+        if self.config.pipe_config.ema.enabled:
+            # calculate beta for EMA update
+            ema_beta = self.ema_beta(iteration)
+            self.pipe.dit_ema_worker.update_average(self.net, self.net_ema, beta=ema_beta)
+
+    # New function, added for i4 adaption
+    def on_train_start(self, memory_format: torch.memory_format = torch.preserve_format) -> None:
+        if self.config.pipe_config.ema.enabled:
+            self.net_ema.to(dtype=torch.float32)
+        for module in [self.net, self.pipe.tokenizer]:
+            if module is not None:
+                module.to(memory_format=memory_format, **self.tensor_kwargs)
+
+    def freeze_parameters(self) -> None:
+        # Freeze parameters
+        self.pipe.requires_grad_(False)
+        self.pipe.eval()
+        self.pipe.denoising_model().train()
+
+    def add_lora_to_model(
+        self,
+        model,
+        lora_rank=4,
+        lora_alpha=4,
+        lora_target_modules="q_proj,k_proj,v_proj,output_proj,mlp.layer1,mlp.layer2",
+        init_lora_weights=True,
+    ):
+        from peft import LoraConfig, inject_adapter_in_model
+
+        # Add LoRA to UNet
+        self.lora_alpha = lora_alpha
+
+        lora_config = LoraConfig(
+            r=lora_rank,
+            lora_alpha=lora_alpha,
+            init_lora_weights=init_lora_weights,
+            target_modules=lora_target_modules.split(","),
+        )
+        model = inject_adapter_in_model(lora_config, model)
+        for param in model.parameters():
+            # Upcast LoRA parameters into fp32
+            if param.requires_grad:
+                param.data = param.to(torch.float32)
+
+    def setup_data_key(self) -> None:
+        self.input_data_key = self.config.input_data_key  # by default it is video key for Video diffusion model
+        self.input_image_key = self.config.input_image_key
+
+    def is_image_batch(self, data_batch: dict[str, torch.Tensor]) -> bool:
+        """We hanlde two types of data_batch. One comes from a joint_dataloader where "dataset_name" can be used to differenciate image_batch and video_batch.
+        Another comes from a dataloader which we by default assumes as video_data for video model training.
+        """
+        is_image = self.input_image_key in data_batch
+        is_video = self.input_data_key in data_batch
+        assert (
+            is_image != is_video
+        ), "Only one of the input_image_key or input_data_key should be present in the data_batch."
+        return is_image
+
+    def _update_train_stats(self, data_batch: dict[str, torch.Tensor]) -> None:
+        is_image = self.is_image_batch(data_batch)
+        input_key = self.input_image_key if is_image else self.input_data_key
+        if isinstance(self.pipe.dit, WeightTrainingStat):
+            if is_image:
+                self.pipe.dit.accum_image_sample_counter += data_batch[input_key].shape[0] * self.data_parallel_size
+            else:
+                self.pipe.dit.accum_video_sample_counter += data_batch[input_key].shape[0] * self.data_parallel_size
+
+    def draw_training_sigma_and_epsilon(self, x0_size: torch.Size, condition: Any) -> Tuple[torch.Tensor, torch.Tensor]:
+        batch_size = x0_size[0]
+        epsilon = torch.randn(x0_size, device="cuda")
+        sigma_B = self.pipe.scheduler.sample_sigma(batch_size).to(device="cuda")
+        sigma_B_1 = rearrange(sigma_B, "b -> b 1")  # add a dimension for T, all frames share the same sigma
+
+        return sigma_B_1, epsilon
+
+    def get_per_sigma_loss_weights(self, sigma: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            sigma (tensor): noise level
+
+        Returns:
+            loss weights per sigma noise level
+        """
+        return (sigma**2 + self.pipe.sigma_data**2) / (sigma * self.pipe.sigma_data) ** 2
+
+    def compute_loss_with_epsilon_and_sigma(
+        self,
+        x0_B_C_T_H_W: torch.Tensor,
+        condition: T2VCondition,
+        epsilon_B_C_T_H_W: torch.Tensor,
+        sigma_B_T: torch.Tensor,
+    ) -> Tuple[dict, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """
+        Compute loss givee epsilon and sigma
+
+        This method is responsible for computing loss give epsilon and sigma. It involves:
+        1. Adding noise to the input data.
+        2. Passing the noisy data through the network to generate predictions.
+        3. Computing the loss based on the difference between the predictions and the original data, \
+            considering any configured loss weighting.
+
+        Args:
+            data_batch (dict): raw data batch draw from the training data loader.
+            x0: image/video latent
+            condition: text condition
+            epsilon: noise
+            sigma: noise level
+
+        Returns:
+            tuple: A tuple containing four elements:
+                - dict: additional data that used to debug / logging / callbacks
+                - Tensor 1: kendall loss,
+                - Tensor 2: MSE loss,
+                - Tensor 3: EDM loss
+
+        Raises:
+            AssertionError: If the class is conditional, \
+                but no number of classes is specified in the network configuration.
+
+        Notes:
+            - The method handles different types of conditioning
+            - The method also supports Kendall's loss
+        """
+        # Get the mean and stand deviation of the marginal probability distribution.
+        mean_B_C_T_H_W, std_B_T = x0_B_C_T_H_W, sigma_B_T
+        # Generate noisy observations
+        xt_B_C_T_H_W = mean_B_C_T_H_W + epsilon_B_C_T_H_W * rearrange(std_B_T, "b t -> b 1 t 1 1")
+        # make prediction
+        model_pred = self.pipe.denoise(xt_B_C_T_H_W, sigma_B_T, condition)
+        # loss weights for different noise levels
+        weights_per_sigma_B_T = self.get_per_sigma_loss_weights(sigma=sigma_B_T)
+        # extra loss mask for each sample, for example, human faces, hands
+        pred_mse_B_C_T_H_W = (x0_B_C_T_H_W - model_pred.x0) ** 2
+        edm_loss_B_C_T_H_W = pred_mse_B_C_T_H_W * rearrange(weights_per_sigma_B_T, "b t -> b 1 t 1 1")
+        kendall_loss = edm_loss_B_C_T_H_W
+        output_batch = {
+            "x0": x0_B_C_T_H_W,
+            "xt": xt_B_C_T_H_W,
+            "sigma": sigma_B_T,
+            "weights_per_sigma": weights_per_sigma_B_T,
+            "condition": condition,
+            "model_pred": model_pred,
+            "mse_loss": pred_mse_B_C_T_H_W.mean(),
+            "edm_loss": edm_loss_B_C_T_H_W.mean(),
+            "edm_loss_per_frame": torch.mean(edm_loss_B_C_T_H_W, dim=[1, 3, 4]),
+        }
+        output_batch["loss"] = kendall_loss.mean()  # check if this is what we want
+
+        return output_batch, kendall_loss, pred_mse_B_C_T_H_W, edm_loss_B_C_T_H_W
+
+    def training_step(self, data_batch: dict, data_batch_idx: int) -> tuple[dict, torch.Tensor]:
+        self.pipe.device = self.device
+
+        # Loss
+        self._update_train_stats(data_batch)
+
+        # Get the input data to noise and denoise~(image, video) and the corresponding conditioner.
+        _, x0_B_C_T_H_W, condition = self.pipe.get_data_and_condition(data_batch)
+
+        # Sample pertubation noise levels and N(0, 1) noises
+        sigma_B_T, epsilon_B_C_T_H_W = self.draw_training_sigma_and_epsilon(x0_B_C_T_H_W.size(), condition)
+
+        # Broadcast and split the input data and condition for model parallelism
+        x0_B_C_T_H_W, condition, epsilon_B_C_T_H_W, sigma_B_T = self.pipe.broadcast_split_for_model_parallelsim(
+            x0_B_C_T_H_W, condition, epsilon_B_C_T_H_W, sigma_B_T
+        )
+        output_batch, kendall_loss, _, _ = self.compute_loss_with_epsilon_and_sigma(
+            x0_B_C_T_H_W, condition, epsilon_B_C_T_H_W, sigma_B_T
+        )
+
+        if self.loss_reduce == "mean":
+            kendall_loss = kendall_loss.mean() * self.loss_scale
+        elif self.loss_reduce == "sum":
+            kendall_loss = kendall_loss.sum(dim=1).mean() * self.loss_scale
+        else:
+            raise ValueError(f"Invalid loss_reduce: {self.loss_reduce}")
+
+        return output_batch, kendall_loss
+
+    # ------------------ Checkpointing ------------------
+
+    def state_dict(self) -> Dict[str, Any]:
+        # the checkpoint format should be compatible with traditional imaginaire4
+        # pipeline contains both net and net_ema
+        # checkpoint should be saved/loaded from Model
+        # checkpoint should be loadable from pipeline as well - We don't use Model for inference only jobs.
+
+        net_state_dict = self.pipe.dit.state_dict(prefix="net.")
+        if self.config.pipe_config.ema.enabled:
+            ema_state_dict = self.pipe.dit_ema.state_dict(prefix="net_ema.")
+            net_state_dict.update(ema_state_dict)
+
+        # convert DTensor to Tensor
+        for key, val in net_state_dict.items():
+            if isinstance(val, DTensor):
+                # Convert to full tensor
+                net_state_dict[key] = val.full_tensor().detach().cpu()
+            else:
+                net_state_dict[key] = val.detach().cpu()
+
+        return net_state_dict
+
+    def load_state_dict(self, state_dict: Mapping[str, Any], strict: bool = True, assign: bool = False):
+        """
+        Loads a state dictionary into the model and optionally its EMA counterpart.
+        Different from torch strict=False mode, the method will not raise error for unmatched state shape while raise warning.
+
+        Parameters:e
+            state_dict (Mapping[str, Any]): A dictionary containing separate state dictionaries for the model and
+                                            potentially for an EMA version of the model under the keys 'model' and 'ema', respectively.
+            strict (bool, optional): If True, the method will enforce that the keys in the state dict match exactly
+                                    those in the model and EMA model (if applicable). Defaults to True.
+            assign (bool, optional): If True and in strict mode, will assign the state dictionary directly rather than
+                                    matching keys one-by-one. This is typically used when loading parts of state dicts
+                                    or using customized loading procedures. Defaults to False.
+        """
+        _reg_state_dict = collections.OrderedDict()
+        _ema_state_dict = collections.OrderedDict()
+        for k, v in state_dict.items():
+            if k.startswith("net."):
+                _reg_state_dict[k.replace("net.", "")] = v
+            elif k.startswith("net_ema."):
+                _ema_state_dict[k.replace("net_ema.", "")] = v
+
+        state_dict = _reg_state_dict
+
+        if strict:
+            reg_results: _IncompatibleKeys = self.pipe.dit.load_state_dict(
+                _reg_state_dict, strict=strict, assign=assign
+            )
+
+            if self.config.pipe_config.ema.enabled:
+                ema_results: _IncompatibleKeys = self.pipe.dit_ema.load_state_dict(
+                    _ema_state_dict, strict=strict, assign=assign
+                )
+
+            return _IncompatibleKeys(
+                missing_keys=reg_results.missing_keys
+                + (ema_results.missing_keys if self.config.pipe_config.ema.enabled else []),
+                unexpected_keys=reg_results.unexpected_keys
+                + (ema_results.unexpected_keys if self.config.pipe_config.ema.enabled else []),
+            )
+        else:
+            log.critical("load model in non-strict mode")
+            log.critical(non_strict_load_model(self.pipe.dit, _reg_state_dict), rank0_only=False)
+            if self.config.pipe_config.ema.enabled:
+                log.critical("load ema model in non-strict mode")
+                log.critical(non_strict_load_model(self.pipe.dit_ema, _ema_state_dict), rank0_only=False)
+
+    # ------------------ public methods ------------------
+    def ema_beta(self, iteration: int) -> float:
+        """
+        Calculate the beta value for EMA update.
+        weights = weights * beta + (1 - beta) * new_weights
+
+        Args:
+            iteration (int): Current iteration number.
+
+        Returns:
+            float: The calculated beta value.
+        """
+        iteration = iteration + self.config.pipe_config.ema.iteration_shift
+        if iteration < 1:
+            return 0.0
+        return (1 - 1 / (iteration + 1)) ** (self.pipe.ema_exp_coefficient + 1)
+
+    def clip_grad_norm_(
+        self,
+        max_norm: float,
+        norm_type: float = 2.0,
+        error_if_nonfinite: bool = False,
+        foreach: Optional[bool] = None,
+    ) -> torch.Tensor:
+        return clip_grad_norm_(
+            self.net.parameters(),
+            max_norm,
+            norm_type=norm_type,
+            error_if_nonfinite=error_if_nonfinite,
+            foreach=foreach,
+        )

--- a/cosmos_predict2/models/text2image_model.py
+++ b/cosmos_predict2/models/text2image_model.py
@@ -24,7 +24,7 @@ from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import DTensor
 from torch.nn.modules.module import _IncompatibleKeys
 
-from cosmos_predict2.conditioner import T2VCondition
+from cosmos_predict2.conditioner import TextCondition
 from cosmos_predict2.configs.base.config_text2image import (
     PREDICT2_TEXT2IMAGE_PIPELINE_2B,
     Text2ImagePipelineConfig,
@@ -272,7 +272,7 @@ class Predict2Text2ImageModel(ImaginaireModel):
     def compute_loss_with_epsilon_and_sigma(
         self,
         x0_B_C_T_H_W: torch.Tensor,
-        condition: T2VCondition,
+        condition: TextCondition,
         epsilon_B_C_T_H_W: torch.Tensor,
         sigma_B_T: torch.Tensor,
     ) -> Tuple[dict, torch.Tensor, torch.Tensor, torch.Tensor]:

--- a/cosmos_predict2/models/text2image_model.py
+++ b/cosmos_predict2/models/text2image_model.py
@@ -56,7 +56,7 @@ class Predict2Text2ImageModelConfig:
     init_lora_weights: bool = True
 
     precision: str = "bfloat16"
-    input_data_key: str = "video"
+    input_video_key: str = "video"
     input_image_key: str = "images"
     loss_reduce: str = "mean"
     loss_scale: float = 10.0
@@ -228,7 +228,7 @@ class Predict2Text2ImageModel(ImaginaireModel):
                 param.data = param.to(torch.float32)
 
     def setup_data_key(self) -> None:
-        self.input_data_key = self.config.input_data_key  # by default it is video key for Video diffusion model
+        self.input_video_key = self.config.input_video_key  # by default it is video key for Video diffusion model
         self.input_image_key = self.config.input_image_key
 
     def is_image_batch(self, data_batch: dict[str, torch.Tensor]) -> bool:
@@ -236,15 +236,15 @@ class Predict2Text2ImageModel(ImaginaireModel):
         Another comes from a dataloader which we by default assumes as video_data for video model training.
         """
         is_image = self.input_image_key in data_batch
-        is_video = self.input_data_key in data_batch
+        is_video = self.input_video_key in data_batch
         assert (
             is_image != is_video
-        ), "Only one of the input_image_key or input_data_key should be present in the data_batch."
+        ), "Only one of the input_image_key or input_video_key should be present in the data_batch."
         return is_image
 
     def _update_train_stats(self, data_batch: dict[str, torch.Tensor]) -> None:
         is_image = self.is_image_batch(data_batch)
-        input_key = self.input_image_key if is_image else self.input_data_key
+        input_key = self.input_image_key if is_image else self.input_video_key
         if isinstance(self.pipe.dit, WeightTrainingStat):
             if is_image:
                 self.pipe.dit.accum_image_sample_counter += data_batch[input_key].shape[0] * self.data_parallel_size

--- a/cosmos_predict2/models/video2world_model.py
+++ b/cosmos_predict2/models/video2world_model.py
@@ -26,7 +26,10 @@ from torch.distributed.tensor import DTensor
 from torch.nn.modules.module import _IncompatibleKeys
 
 from cosmos_predict2.conditioner import DataType, TextCondition
-from cosmos_predict2.configs.base.config_video2world import PREDICT2_VIDEO2WORLD_PIPELINE_2B, Video2WorldPipelineConfig
+from cosmos_predict2.configs.base.config_video2world import (
+    PREDICT2_VIDEO2WORLD_PIPELINE_2B,
+    Video2WorldPipelineConfig,
+)
 from cosmos_predict2.networks.model_weights_stats import WeightTrainingStat
 from cosmos_predict2.pipelines.video2world import Video2WorldPipeline
 from cosmos_predict2.utils.checkpointer import non_strict_load_model
@@ -54,7 +57,7 @@ class Predict2Video2WorldModelConfig:
     init_lora_weights: bool = True
 
     precision: str = "bfloat16"
-    input_data_key: str = "video"
+    input_video_key: str = "video"
     input_image_key: str = "images"
     loss_reduce: str = "mean"
     loss_scale: float = 10.0
@@ -234,7 +237,7 @@ class Predict2Video2WorldModel(ImaginaireModel):
                 param.data = param.to(torch.float32)
 
     def setup_data_key(self) -> None:
-        self.input_data_key = self.config.input_data_key  # by default it is video key for Video diffusion model
+        self.input_video_key = self.config.input_video_key  # by default it is video key for Video diffusion model
         self.input_image_key = self.config.input_image_key
 
     def is_image_batch(self, data_batch: dict[str, torch.Tensor]) -> bool:
@@ -242,15 +245,15 @@ class Predict2Video2WorldModel(ImaginaireModel):
         Another comes from a dataloader which we by default assumes as video_data for video model training.
         """
         is_image = self.input_image_key in data_batch
-        is_video = self.input_data_key in data_batch
+        is_video = self.input_video_key in data_batch
         assert (
             is_image != is_video
-        ), "Only one of the input_image_key or input_data_key should be present in the data_batch."
+        ), "Only one of the input_image_key or input_video_key should be present in the data_batch."
         return is_image
 
     def _update_train_stats(self, data_batch: dict[str, torch.Tensor]) -> None:
         is_image = self.is_image_batch(data_batch)
-        input_key = self.input_image_key if is_image else self.input_data_key
+        input_key = self.input_image_key if is_image else self.input_video_key
         if isinstance(self.pipe.dit, WeightTrainingStat):
             if is_image:
                 self.pipe.dit.accum_image_sample_counter += data_batch[input_key].shape[0] * self.data_parallel_size

--- a/cosmos_predict2/pipelines/text2image.py
+++ b/cosmos_predict2/pipelines/text2image.py
@@ -57,7 +57,7 @@ def sample_batch_image(resolution: str = "1024", aspect_ratio: str = "16:9", bat
 
 
 def get_sample_batch(
-    resolution: str = "512",
+    resolution: str = "480",
     aspect_ratio: str = "16:9",
     batch_size: int = 1,
 ) -> dict:

--- a/cosmos_predict2/pipelines/text2image.py
+++ b/cosmos_predict2/pipelines/text2image.py
@@ -15,9 +15,12 @@
 
 from typing import Any, List, Tuple, Union
 
+import numpy as np
 import torch
 from einops import rearrange
 from megatron.core import parallel_state
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.fsdp import fully_shard
 from tqdm import tqdm
 
 from cosmos_predict2.auxiliary.text_encoder import CosmosT5TextEncoder
@@ -30,8 +33,13 @@ from cosmos_predict2.module.denoiser_scaling import RectifiedFlowScaling
 from cosmos_predict2.pipelines.base import BasePipeline
 from cosmos_predict2.schedulers.rectified_flow_scheduler import RectifiedFlowAB2Scheduler
 from cosmos_predict2.tokenizers.tokenizer import TokenizerInterface
+from cosmos_predict2.utils.dtensor_helper import (
+    DTensorFastEmaModelUpdater,
+    broadcast_dtensor_model_states,
+)
 from imaginaire.lazy_config import LazyDict, instantiate
 from imaginaire.utils import log, misc
+from imaginaire.utils.ema import FastEmaModelUpdater
 
 IS_PREPROCESSED_KEY = "is_preprocessed"
 
@@ -67,6 +75,7 @@ class Text2ImagePipeline(BasePipeline):
         super().__init__(device=device, torch_dtype=torch_dtype)
         self.text_encoder: CosmosT5TextEncoder = None
         self.dit: MiniTrainDIT = None
+        self.dit_ema: torch.nn.Module = None
         self.tokenizer: TokenizerInterface = None
         self.conditioner = None
         self.text_guardrail_runner = None
@@ -78,8 +87,8 @@ class Text2ImagePipeline(BasePipeline):
     @staticmethod
     def from_config(
         config: LazyDict,
-        dit_path: str = "checkpoints/nvidia/Cosmos-Predict2-2B-Text2Image/model_ema_reg.pt",
-        text_encoder_path: str = "checkpoints/google-t5/t5-11b",
+        dit_path: str = "",
+        text_encoder_path: str = "",
         device: str = "cuda",
         torch_dtype: torch.dtype = torch.bfloat16,
     ) -> Any:
@@ -96,6 +105,7 @@ class Text2ImagePipeline(BasePipeline):
 
         # 1. set data keys and data information
         pipe.sigma_data = config.sigma_data
+        pipe.setup_data_key()
 
         # 2. setup up diffusion processing and scaling~(pre-condition), sampler
         pipe.scheduler = RectifiedFlowAB2Scheduler(
@@ -113,8 +123,13 @@ class Text2ImagePipeline(BasePipeline):
         ), f"latent_ch {pipe.tokenizer.latent_ch} != state_shape {pipe.config.state_ch}"
 
         # 4. Load text encoder
-        pipe.text_encoder = CosmosT5TextEncoder(device=device, cache_dir=text_encoder_path)
-        pipe.text_encoder.to(device)
+        if text_encoder_path:
+            # inference
+            pipe.text_encoder = CosmosT5TextEncoder(device=device, cache_dir=text_encoder_path)
+            pipe.text_encoder.to(device)
+        else:
+            # training
+            pipe.text_encoder = None
 
         # 5. Initialize conditioner
         pipe.conditioner = instantiate(config.conditioner)
@@ -131,25 +146,40 @@ class Text2ImagePipeline(BasePipeline):
         else:
             pipe.text_guardrail_runner = None
 
-        # 6. Load DiT
-        assert dit_path is not None, "dit_path must be provided to load the model"
-        log.info(f"Loading DiT from {dit_path}")
+        # 6. Set up DiT
+        if dit_path:
+            log.info(f"Loading DiT from {dit_path}")
+        else:
+            log.warning("dit_path not provided, initializing DiT with random weights")
         with init_weights_on_device():
             dit_config = config.net
             pipe.dit = instantiate(dit_config).eval()  # inference
 
-        state_dict = load_state_dict(dit_path)
-        # drop net. prefix
-        state_dict_dit_compatible = dict()
-        for k, v in state_dict.items():
-            if k.startswith("net."):
-                state_dict_dit_compatible[k[4:]] = v
-            else:
-                state_dict_dit_compatible[k] = v
-        # pipe.dit.load_state_dict(state_dict, assign=True)
-        pipe.dit.load_state_dict(state_dict_dit_compatible, strict=False, assign=True)
-        del state_dict, state_dict_dit_compatible
-        log.success(f"Successfully loaded DiT from {dit_path}")
+        if dit_path:
+            state_dict = load_state_dict(dit_path)
+            # drop net. prefix
+            state_dict_dit_compatible = dict()
+            for k, v in state_dict.items():
+                if k.startswith("net."):
+                    state_dict_dit_compatible[k[4:]] = v
+                else:
+                    state_dict_dit_compatible[k] = v
+            pipe.dit.load_state_dict(state_dict_dit_compatible, strict=False, assign=True)
+            del state_dict, state_dict_dit_compatible
+            log.success(f"Successfully loaded DiT from {dit_path}")
+
+        # 6-2. Handle EMA
+        if config.ema.enabled:
+            pipe.dit_ema = instantiate(dit_config).eval()
+            pipe.dit_ema.requires_grad_(False)
+
+            pipe.dit_ema_worker = FastEmaModelUpdater()  # default when not using FSDP
+
+            s = config.ema.rate
+            pipe.ema_exp_coefficient = np.roots([1, 7, 16 - s**-2, 12 - s**-2]).real.max()
+            # copying is only necessary when starting the training at iteration 0.
+            # Actual state_dict should be loaded after the pipe is created.
+            pipe.dit_ema_worker.copy_to(src_model=pipe.dit, tgt_model=pipe.dit_ema)
 
         pipe.dit = pipe.dit.to(device=device, dtype=torch_dtype)
         torch.cuda.empty_cache()
@@ -161,6 +191,24 @@ class Text2ImagePipeline(BasePipeline):
             pipe.data_parallel_size = 1
 
         return pipe
+
+    def setup_data_key(self) -> None:
+        self.input_data_key = self.config.input_data_key  # by default it is video key for Video diffusion model
+        self.input_image_key = self.config.input_image_key
+
+    def apply_fsdp(self, dp_mesh: DeviceMesh) -> None:
+        self.dit.fully_shard(mesh=dp_mesh)
+        self.dit = fully_shard(self.dit, mesh=dp_mesh, reshard_after_forward=True)
+        broadcast_dtensor_model_states(self.dit, dp_mesh)
+        if self.dit_ema:
+            self.dit_ema.fully_shard(mesh=dp_mesh)
+            self.dit_ema = fully_shard(self.dit_ema, mesh=dp_mesh, reshard_after_forward=True)
+            broadcast_dtensor_model_states(self.dit_ema, dp_mesh)
+            self.dit_ema_worker = DTensorFastEmaModelUpdater()
+            # No need to copy weights to EMA when applying FSDP, it is already copied before applying FSDP.
+
+    def apply_cp(self) -> None:
+        pass
 
     def denoising_model(self) -> MiniTrainDIT:
         return self.dit

--- a/cosmos_predict2/pipelines/text2image.py
+++ b/cosmos_predict2/pipelines/text2image.py
@@ -31,7 +31,9 @@ from cosmos_predict2.models.utils import init_weights_on_device, load_state_dict
 from cosmos_predict2.module.denoise_prediction import DenoisePrediction
 from cosmos_predict2.module.denoiser_scaling import RectifiedFlowScaling
 from cosmos_predict2.pipelines.base import BasePipeline
-from cosmos_predict2.schedulers.rectified_flow_scheduler import RectifiedFlowAB2Scheduler
+from cosmos_predict2.schedulers.rectified_flow_scheduler import (
+    RectifiedFlowAB2Scheduler,
+)
 from cosmos_predict2.tokenizers.tokenizer import TokenizerInterface
 from cosmos_predict2.utils.dtensor_helper import (
     DTensorFastEmaModelUpdater,
@@ -193,7 +195,7 @@ class Text2ImagePipeline(BasePipeline):
         return pipe
 
     def setup_data_key(self) -> None:
-        self.input_data_key = self.config.input_data_key  # by default it is video key for Video diffusion model
+        self.input_video_key = self.config.input_video_key
         self.input_image_key = self.config.input_image_key
 
     def apply_fsdp(self, dp_mesh: DeviceMesh) -> None:

--- a/cosmos_predict2/pipelines/video2world.py
+++ b/cosmos_predict2/pipelines/video2world.py
@@ -348,16 +348,16 @@ class Video2WorldPipeline(BasePipeline):
 
         if dit_path:
             state_dict = load_state_dict(dit_path)
-        # drop net. prefix
-        state_dict_dit_compatible = dict()
-        for k, v in state_dict.items():
-            if k.startswith("net."):
-                state_dict_dit_compatible[k[4:]] = v
-            else:
-                state_dict_dit_compatible[k] = v
-        pipe.dit.load_state_dict(state_dict_dit_compatible, strict=False, assign=True)
-        del state_dict, state_dict_dit_compatible
-        log.success(f"Successfully loaded DiT from {dit_path}")
+            # drop net. prefix
+            state_dict_dit_compatible = dict()
+            for k, v in state_dict.items():
+                if k.startswith("net."):
+                    state_dict_dit_compatible[k[4:]] = v
+                else:
+                    state_dict_dit_compatible[k] = v
+            pipe.dit.load_state_dict(state_dict_dit_compatible, strict=False, assign=True)
+            del state_dict, state_dict_dit_compatible
+            log.success(f"Successfully loaded DiT from {dit_path}")
 
         # 6-2. Handle EMA
         if config.ema.enabled:

--- a/cosmos_predict2/pipelines/video2world.py
+++ b/cosmos_predict2/pipelines/video2world.py
@@ -30,16 +30,29 @@ from tqdm import tqdm
 from cosmos_predict2.auxiliary.cosmos_reason1 import CosmosReason1
 from cosmos_predict2.auxiliary.text_encoder import CosmosT5TextEncoder
 from cosmos_predict2.conditioner import DataType, TextCondition
-from cosmos_predict2.configs.base.config_video2world import ConditioningStrategy, Video2WorldPipelineConfig
+from cosmos_predict2.configs.base.config_video2world import (
+    ConditioningStrategy,
+    Video2WorldPipelineConfig,
+)
 from cosmos_predict2.datasets.utils import VIDEO_RES_SIZE_INFO
 from cosmos_predict2.models.utils import init_weights_on_device, load_state_dict
 from cosmos_predict2.module.denoise_prediction import DenoisePrediction
 from cosmos_predict2.module.denoiser_scaling import RectifiedFlowScaling
 from cosmos_predict2.pipelines.base import BasePipeline
-from cosmos_predict2.schedulers.rectified_flow_scheduler import RectifiedFlowAB2Scheduler
+from cosmos_predict2.schedulers.rectified_flow_scheduler import (
+    RectifiedFlowAB2Scheduler,
+)
 from cosmos_predict2.tokenizers.tokenizer import TokenizerInterface
-from cosmos_predict2.utils.context_parallel import broadcast, broadcast_split_tensor, cat_outputs_cp, split_inputs_cp
-from cosmos_predict2.utils.dtensor_helper import DTensorFastEmaModelUpdater, broadcast_dtensor_model_states
+from cosmos_predict2.utils.context_parallel import (
+    broadcast,
+    broadcast_split_tensor,
+    cat_outputs_cp,
+    split_inputs_cp,
+)
+from cosmos_predict2.utils.dtensor_helper import (
+    DTensorFastEmaModelUpdater,
+    broadcast_dtensor_model_states,
+)
 from imaginaire.lazy_config import instantiate
 from imaginaire.utils import log, misc
 from imaginaire.utils.easy_io import easy_io
@@ -384,7 +397,7 @@ class Video2WorldPipeline(BasePipeline):
         return pipe
 
     def setup_data_key(self) -> None:
-        self.input_data_key = self.config.input_data_key  # by default it is video key for Video diffusion model
+        self.input_video_key = self.config.input_video_key  # by default it is video key for Video diffusion model
         self.input_image_key = self.config.input_image_key
 
     def apply_fsdp(self, dp_mesh: DeviceMesh) -> None:
@@ -473,14 +486,14 @@ class Video2WorldPipeline(BasePipeline):
                 This tensor is expected to be on a CUDA device and have dtype of torch.uint8.
 
         Side Effects:
-            Modifies the 'input_data_key' tensor within the 'data_batch' dictionary in-place.
+            Modifies the 'input_video_key' tensor within the 'data_batch' dictionary in-place.
 
         Note:
             This operation is performed directly on the CUDA device to avoid the overhead associated
             with moving data to/from the GPU. Ensure that the tensor is already on the appropriate device
             and has the correct dtype (torch.uint8) to avoid unexpected behaviors.
         """
-        input_key = self.input_data_key if input_key is None else input_key
+        input_key = self.input_video_key if input_key is None else input_key
         # only handle video batch
         if input_key in data_batch:
             # Check if the data has already been normalized and avoid re-normalizing
@@ -565,7 +578,7 @@ class Video2WorldPipeline(BasePipeline):
         is_image_batch = self.is_image_batch(data_batch)
 
         # Latent state
-        raw_state = data_batch[self.input_image_key if is_image_batch else self.input_data_key]
+        raw_state = data_batch[self.input_image_key if is_image_batch else self.input_video_key]
         latent_state = self.encode(raw_state).contiguous().float()
 
         # Condition
@@ -585,10 +598,10 @@ class Video2WorldPipeline(BasePipeline):
         Another comes from a dataloader which we by default assumes as video_data for video model training.
         """
         is_image = self.input_image_key in data_batch
-        is_video = self.input_data_key in data_batch
+        is_video = self.input_video_key in data_batch
         assert (
             is_image != is_video
-        ), "Only one of the input_image_key or input_data_key should be present in the data_batch."
+        ), "Only one of the input_image_key or input_video_key should be present in the data_batch."
         return is_image
 
     def denoise(
@@ -845,7 +858,7 @@ class Video2WorldPipeline(BasePipeline):
         self._normalize_video_databatch_inplace(data_batch)
         self._augment_image_dim_inplace(data_batch)
         is_image_batch = self.is_image_batch(data_batch)
-        input_key = self.input_image_key if is_image_batch else self.input_data_key
+        input_key = self.input_image_key if is_image_batch else self.input_video_key
         n_sample = data_batch[input_key].shape[0]
         _T, _H, _W = data_batch[input_key].shape[-3:]
         state_shape = [

--- a/cosmos_predict2/pipelines/video2world_action.py
+++ b/cosmos_predict2/pipelines/video2world_action.py
@@ -25,7 +25,9 @@ from cosmos_predict2.configs.base.config_video2world import Video2WorldPipelineC
 from cosmos_predict2.models.utils import load_state_dict
 from cosmos_predict2.module.denoiser_scaling import RectifiedFlowScaling
 from cosmos_predict2.pipelines.video2world import Video2WorldPipeline
-from cosmos_predict2.schedulers.rectified_flow_scheduler import RectifiedFlowAB2Scheduler
+from cosmos_predict2.schedulers.rectified_flow_scheduler import (
+    RectifiedFlowAB2Scheduler,
+)
 from cosmos_predict2.utils.context_parallel import cat_outputs_cp, split_inputs_cp
 from imaginaire.lazy_config import instantiate
 from imaginaire.utils import log, misc
@@ -250,7 +252,7 @@ class Video2WorldActionConditionedPipeline(Video2WorldPipeline):
         self._normalize_video_databatch_inplace(data_batch)
         self._augment_image_dim_inplace(data_batch)
         is_image_batch = self.is_image_batch(data_batch)
-        input_key = self.input_image_key if is_image_batch else self.input_data_key
+        input_key = self.input_image_key if is_image_batch else self.input_video_key
         n_sample = data_batch[input_key].shape[0]
         _T, _H, _W = data_batch[input_key].shape[-3:]
         state_shape = [

--- a/documentations/post-training_text2image.md
+++ b/documentations/post-training_text2image.md
@@ -123,10 +123,10 @@ predict2_text2image_training_2b_custom_data = dict(
         weight_decay=0.2,
     ),
     scheduler=dict(
-        warm_up_steps=[2_000],
-        cycle_lengths=[400_000],
+        warm_up_steps=[0],
+        cycle_lengths=[1_000],              # adjust considering max_iter
         f_max=[0.4],
-        f_min=[0.1],
+        f_min=[0.0],
     ),
 )
 ```

--- a/documentations/post-training_text2image.md
+++ b/documentations/post-training_text2image.md
@@ -1,6 +1,6 @@
-# Predict2 Video2World Post-Training Guide
+# Predict2 Text2Image Post-Training Guide
 
-This guide provides instructions on running post-training with Cosmos-Predict2 Video2World models.
+This guide provides instructions on running post-training with Cosmos-Predict2 Text2Image models.
 
 ## Table of Contents
 - [Prerequisites](#prerequisites)
@@ -17,16 +17,12 @@ Before running training:
 
 ## Overview
 
-Cosmos-Predict2 provides two models for generating videos from a combination of text and visual inputs: `Cosmos-Predict2-2B-Video2World` and `Cosmos-Predict2-14B-Video2World`. These models can transform a still image or video clip into a longer, animated sequence guided by the text description.
+Cosmos-Predict2 provides two models for generating videos from a combination of text and visual inputs: `Cosmos-Predict2-2B-Text2Image` and `Cosmos-Predict2-14B-Text2Image`. These models can transform a still image or video clip into a longer, animated sequence guided by the text description.
 
 We support post-training the models with example datasets.
-- [post-training_video2world_cosmos_nemo_assets](/documentations/post-training_video2world_cosmos_nemo_assets.md)
+- [post-training_text2image_cosmos_nemo_assets](/documentations/post-training_text2image_cosmos_nemo_assets.md)
   - Basic examples with a small 4 videos dataset
-- [post-training_video2world_agibot_fisheye](/documentations/post-training_video2world_agibot_fisheye.md)
-  - Examples with fisheye-view dataset
-  - Post-training from checkpoints with resolution & fps choices
-- [post-training_video2world_gr00t](/documentations/post-training_video2world_gr00t.md)
-  - Examples with GR00T-dreams datasets
+
 ## Post-training Guide
 
 ### 1. Preparing Data
@@ -36,27 +32,27 @@ For example, a custom dataset can be saved in a following structure.
 
 Dataset folder format:
 ```
-datasets/custom_video2world_dataset/
+datasets/custom_text2image_dataset/
 ├── metas/
 │   ├── *.txt
-├── videos/
-│   ├── *.mp4
+├── images/
+│   ├── *.jpg
 ```
 
 `metas` folder contains `.txt` files containing prompts describing the video content.
 `videow` folder contains the corresponding `.mp4` video files.
 
-After preparing `metas` and `videos` folders, run the following command to pre-compute T5-XXL embeddings.
+After preparing `metas` and `images` folders, run the following command to pre-compute T5-XXL embeddings.
 ```bash
-python -m scripts.get_t5_embeddings --dataset_path datasets/custom_video2world_dataset/
+python -m scripts.get_t5_embeddings --dataset_path datasets/custom_text2image_dataset/
 ```
 This script will create `t5_xxl` folder under the dataset root where the T5-XXL embeddings are saved as `.pickle` files.
 ```
-datasets/custom_video2world_dataset/
+datasets/custom_text2image_dataset/
 ├── metas/
 │   ├── *.txt
-├── videos/
-│   ├── *.mp4
+├── images/
+│   ├── *.jpg
 ├── t5_xxl/
 │   ├── *.pickle
 ```
@@ -68,15 +64,14 @@ Define dataloader from the prepared dataset.
 For example,
 ```python
 # custom dataset example
-example_video_dataset = L(Dataset)(
-    dataset_dir="datasets/custom_video2world_dataset",
-    num_frames=93,
-    video_size=(704, 1280),  # 720 resolution, 16:9 aspect ratio
+example_image_dataset = L(Dataset)(
+    dataset_dir="datasets/custom_text2image_dataset",
+    image_size=(768, 1360),  # 1024 resolution, 16:9 aspect ratio
 )
 
-dataloader_video_train = L(DataLoader)(
-    dataset=example_video_dataset,
-    sampler=L(get_sampler)(dataset=example_video_dataset),
+dataloader_image_train = L(DataLoader)(
+    dataset=example_image_dataset,
+    sampler=L(get_sampler)(dataset=example_image_dataset),
     batch_size=1,
     drop_last=True,
     num_workers=8,
@@ -84,36 +79,35 @@ dataloader_video_train = L(DataLoader)(
 )
 ```
 
-With the `dataloader_video_train`, create a config for a training job.
-Here's a post-training example for video2world 2B model.
+With the `dataloader_image_train`, create a config for a training job.
+Here's a post-training example for text2image 2B model.
 ```python
-predict2_video2world_training_2b_custom_data = dict(
+predict2_text2image_training_2b_custom_data = dict(
     defaults=[
-        {"override /model": "predict2_video2world_fsdp_2b"},
+        {"override /model": "predict2_text2image_fsdp_2b"},
         {"override /optimizer": "fusedadamw"},
         {"override /scheduler": "lambdalinear"},
         {"override /ckpt_type": "standard"},
-        {"override /dataloader_val": "mock"},
+        {"override /dataloader_val": "mock_image"},
         "_self_",
     ],
     job=dict(
         project="posttraining",
-        group="video2world",
+        group="text2image",
         name="2b_custom_data",
     ),
     model=dict(
         config=dict(
             pipe_config=dict(
                 ema=dict(enabled=True),     # enable EMA during training
-                prompt_refiner_config=dict(enabled=False),  # disable prompt refiner during training
                 guardrail_config=dict(enabled=False),   # disable guardrail during training
             ),
         )
     ),
     model_parallel=dict(
-        context_parallel_size=2,            # context parallelism size
+        context_parallel_size=1,            # context parallelism size
     ),
-    dataloader_train=dataloader_video_train,
+    dataloader_train=dataloader_image_train,
     trainer=dict(
         distributed_parallelism="fsdp",
         callbacks=dict(
@@ -126,12 +120,13 @@ predict2_video2world_training_2b_custom_data = dict(
     ),
     optimizer=dict(
         lr=2 ** (-14.5),
+        weight_decay=0.2,
     ),
     scheduler=dict(
         warm_up_steps=[2_000],
         cycle_lengths=[400_000],
-        f_max=[0.6],
-        f_min=[0.3],
+        f_max=[0.4],
+        f_min=[0.1],
     ),
 )
 ```
@@ -140,7 +135,7 @@ The config should be registered to ConfigStore.
 ```python
 for _item in [
     # 2b, custom data
-    predict2_video2world_training_2b_custom_data,
+    predict2_text2image_training_2b_custom_data,
 ]:
     # Get the experiment name from the global variable.
     experiment_name = [name.lower() for name, value in globals().items() if value is _item][0]
@@ -157,11 +152,11 @@ for _item in [
 
 In the above config example, it starts by overriding from the registered configs.
 ```python
-    {"override /model": "predict2_video2world_fsdp_2b"},
+    {"override /model": "predict2_text2image_fsdp_2b"},
     {"override /optimizer": "fusedadamw"},
     {"override /scheduler": "lambdalinear"},
     {"override /ckpt_type": "standard"},
-    {"override /dataloader_val": "mock"},
+    {"override /dataloader_val": "mock_image"},
 ```
 
 The configuration system is organized as follows:
@@ -179,8 +174,6 @@ cosmos_predict2/configs/base/
 │   └── scheduler.py            # Learning rate scheduler configurations
 └── experiment/                 # Experiment-specific configurations
     ├── cosmos_nemo_assets.py   # Experiments with cosmos_nemo_assets
-    ├── agibot_head_center_fisheye_color.py  # Experiments with agibot_head_center_fisheye_color
-    ├── groot.py                # Experiments with groot
     └── utils.py                # Utility functions for experiments
 ```
 
@@ -188,8 +181,8 @@ cosmos_predict2/configs/base/
 The system provides several pre-defined configuration groups that can be mixed and matched:
 
 #### Model Configurations (`defaults/model.py`)
-- `predict2_video2world_fsdp_2b`: 2B parameter Video2World model with FSDP
-- `predict2_video2world_fsdp_14b`: 14B parameter Video2World model with FSDP
+- `predict2_text2image_fsdp_2b`: 2B parameter Text2Image model with FSDP
+- `predict2_text2image_fsdp_14b`: 14B parameter Text2Image model with FSDP
 
 #### Optimizer Configurations (`defaults/optimizer.py`)
 - `fusedadamw`: FusedAdamW optimizer with standard settings
@@ -217,17 +210,17 @@ In addition to the overrided values, the rest of the config setup overwrites or 
 
 Run the following command to execute an example post-training job with the custom data.
 ```bash
-EXP=predict2_video2world_training_2b_custom_data
+EXP=predict2_text2image_training_2b_custom_data
 torchrun --nproc_per_node=8 --master_port=12341 -m scripts.train --config=cosmos_predict2/configs/base/config.py -- experiment=${EXP}
 ```
 
 The above command will train the entire model. If you are interested in training with LoRA, attach `model.config.train_architecture=lora` to the training command.
 
 The checkpoints will be saved to `checkpoints/PROJECT/GROUP/NAME`.
-In the above example, `PROJECT` is `posttraining`, `GROUP` is `video2world`, `NAME` is `2b_custom_data`.
+In the above example, `PROJECT` is `posttraining`, `GROUP` is `text2image`, `NAME` is `2b_custom_data`.
 
 ```
-checkpoints/posttraining/video2world/2b_custom_data/checkpoints/
+checkpoints/posttraining/text2image/2b_custom_data/checkpoints/
 ├── model/
 │   ├── iter_{NUMBER}.pt
 ├── optim/
@@ -238,22 +231,21 @@ checkpoints/posttraining/video2world/2b_custom_data/checkpoints/
 
 ### 4. Run Inference on Post-trained Checkpoints
 
-##### Cosmos-Predict2-2B-Video2World
+##### Cosmos-Predict2-2B-Text2Image
 
 For example, if a posttrained checkpoint with 1000 iterations is to be used, run the following command.
 Use `--dit_path` argument to specify the path to the post-trained checkpoint.
 
 ```bash
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python examples/video2world.py \
+CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python examples/text2image.py \
   --model_size 2B \
-  --dit_path "checkpoints/posttraining/video2world/2b_custom_data/checkpoints/model/iter_000001000.pt" \
+  --dit_path "checkpoints/posttraining/text2image/2b_custom_data/checkpoints/model/iter_000001000.pt" \
   --prompt "A descriptive prompt for physical AI." \
-  --input_path "assets/video2world_cosmos_nemo_assets/output_Digit_Lift_movie.jpg" \
-  --save_path output/cosmos_nemo_assets/generated_video_from_post-training.mp4
+  --save_path output/cosmos_nemo_assets/generated_image_from_post-training.mp4
 ```
 
-See [documentations/inference_video2world.md](documentations/inference_video2world.md) for inference run details.
+See [documentations/inference_text2image.md](documentations/inference_text2image.md) for inference run details.
 
-##### Cosmos-Predict2-14B-Video2World
+##### Cosmos-Predict2-14B-Text2Image
 
 The 14B model can be run similarly by changing the `--model_size` and `--dit_path` arguments.

--- a/documentations/post-training_text2image_cosmos_nemo_assets.md
+++ b/documentations/post-training_text2image_cosmos_nemo_assets.md
@@ -1,0 +1,172 @@
+# Text2Image Post-training for Cosmos-NeMo-Assets
+
+This guide provides instructions on running post-training with Cosmos-Predict2 Text2Image models.
+
+## Table of Contents
+- [Prerequisites](#prerequisites)
+- [Preparing Data](#1-preparing-data)
+- [Post-training](#2-post-training)
+- [Inference with the Post-trained checkpoint](#3-inference-with-the-post-trained-checkpoint)
+
+## Prerequisites
+
+Before running training:
+
+1. **Environment setup**: Follow the [Setup guide](setup.md) for installation instructions.
+2. **Model checkpoints**: Download required model weights following the [Downloading Checkpoints](setup.md#downloading-checkpoints) section in the Setup guide.
+3. **Hardware considerations**: Review the [Performance guide](performance.md) for GPU requirements and model selection recommendations.
+
+
+## 1. Preparing Data
+### 1.1 Downloading Cosmos-NeMo-Assets
+
+The first step is downloading a dataset with videos.
+
+You must provide a folder containing a collection of videos in **MP4 format**, preferably 720p. These videos should focus on the subject throughout the entire video so that each video chunk contains the subject.
+
+You can use [nvidia/Cosmos-NeMo-Assets](https://huggingface.co/datasets/nvidia/Cosmos-NeMo-Assets) for post-training.
+
+```bash
+mkdir -p datasets/benchmark_train/cosmos_nemo_assets/
+
+# This command will download the videos for physical AI
+huggingface-cli download nvidia/Cosmos-NeMo-Assets --repo-type dataset --local-dir datasets/benchmark_train/cosmos_nemo_assets/ --include "*.mp4*"
+
+mv datasets/benchmark_train/cosmos_nemo_assets/nemo_diffusion_example_data datasets/benchmark_train/cosmos_nemo_assets/videos
+```
+
+### 1.2 Preprocessing the Data
+
+Cosmos-NeMo-Assets comes with a single caption for 4 long videos.
+Run the following command to pre-compute T5-XXL embeddings for the video caption used for post-training:
+```bash
+# The script will use the provided prompt, save the T5-XXL embeddings in pickle format.
+PYTHONPATH=$(pwd) python scripts/get_t5_embeddings_from_cosmos_nemo_assets.py --dataset_path datasets/benchmark_train/cosmos_nemo_assets --prompt "A video of sks teal robot."
+```
+
+Dataset folder format:
+```
+datasets/benchmark_train/cosmos_nemo_assets/
+├── metas/
+│   ├── *.txt
+├── videos/
+│   ├── *.mp4
+├── t5_xxl/
+│   ├── *.pickle
+```
+
+In this example, we extract video frames and save as jpg files to prepare a dataset for text2image training.
+```bash
+python -m scripts.extract_images_from_videos --input_dataset_dir datasets/benchmark_train/cosmos_nemo_assets --output_dataset_dir datasets/benchmark_train/cosmos_nemo_assets_images --stride 5
+```
+
+Dataset folder format:
+```
+datasets/benchmark_train/cosmos_nemo_assets_images/
+├── images/
+│   ├── *.mp4
+├── t5_xxl/
+│   ├── *.pickle
+```
+
+## 2. Post-training
+### 2.1. Post-training on Cosmos-NeMo-Assets dataset
+#### Cosmos-Predict2-2B-Text2Image
+
+Run the following command to execute an example post-training job with `cosmos_nemo_assets_images` data.
+```bash
+EXP=predict2_text2image_training_2b_cosmos_nemo_assets
+torchrun --nproc_per_node=1 --master_port=12341 -m scripts.train --config=cosmos_predict2/configs/base/config.py -- experiment=${EXP}
+```
+
+The model will be post-trained using the cosmos_nemo_assets dataset.
+See the config `predict2_text2image_training_2b_cosmos_nemo_assets` defined in `cosmos_predict2/configs/base/experiment/cosmos_nemo_assets.py` to understand how the dataloader is defined.
+```python
+# Cosmos-NeMo-Assets text2image example
+example_image_dataset_cosmos_nemo_assets_images = L(ImageDataset)(
+    dataset_dir="datasets/benchmark_train/cosmos_nemo_assets_images",
+    image_size=(704, 1280),
+)
+
+dataloader_train_cosmos_nemo_assets_images = L(DataLoader)(
+    dataset=example_image_dataset_cosmos_nemo_assets_images,
+    sampler=L(get_sampler)(dataset=example_image_dataset_cosmos_nemo_assets_images),
+    batch_size=1,
+    drop_last=True,
+    num_workers=8,
+    pin_memory=True,
+)
+```
+
+The checkpoints will be saved to `checkpoints/PROJECT/GROUP/NAME`.
+In the above example, `PROJECT` is `posttraining`, `GROUP` is `text2image`, `NAME` is `2b_cosmos_nemo_assets`.
+
+See the job config to understand how they are determined.
+```python
+predict2_text2image_training_2b_cosmos_nemo_assets = dict(
+    dict(
+        ...
+        job=dict(
+            project="posttraining",
+            group="text2image",
+            name="2b_cosmos_nemo_assets",
+        ),
+        ...
+    )
+)
+```
+
+The checkpoints will be saved in the below structure.
+```
+checkpoints/posttraining/text2image/2b_cosmos_nemo_assets/checkpoints/
+├── model/
+│   ├── iter_{NUMBER}.pt
+├── optim/
+├── scheduler/
+├── trainer/
+├── latest_checkpoint.txt
+```
+
+#### Cosmos-Predict2-14B-Text2Image
+
+Run the following command to execute an example post-training job with `cosmos_nemo_assets_images` data with 8 GPUs.
+
+```bash
+EXP=predict2_text2image_training_14b_cosmos_nemo_assets
+torchrun --nproc_per_node=8 -m scripts.train --config=cosmos_predict2/configs/base/config.py -- experiment=${EXP}
+```
+
+The above command will train the entire model. If you are interested in training with [LoRA](https://arxiv.org/abs/2106.09685), attach `model.config.train_architecture=lora` to the training command.
+
+The checkpoints will be saved in the below structure.  
+```
+checkpoints/posttraining/text2image/14b_cosmos_nemo_assets/checkpoints/
+├── model/
+│   ├── iter_{NUMBER}.pt
+├── optim/
+├── scheduler/
+├── trainer/
+├── latest_checkpoint.txt
+```
+
+
+## 3. Inference with the Post-trained checkpoint
+### 3.1 Inference
+##### Cosmos-Predict2-2B-Text2Image
+
+For example, if a posttrained checkpoint with 1000 iterations is to be used, run the following command.
+Use `--dit_path` argument to specify the path to the post-trained checkpoint.
+
+```bash
+CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python examples/text2image.py \
+  --model_size 2B \
+  --dit_path "checkpoints/posttraining/text2image/predict2_text2image_training_2b_cosmos_nemo_assets/checkpoints/model/iter_000001000.pt" \
+  --prompt "An image of sks teal robot." \
+  --save_path results/cosmos_nemo_assets/generated_video_teal_robot.jpg
+```
+
+See [documentations/inference_text2image.md](documentations/inference_text2image.md) for inference run details.
+
+##### Cosmos-Predict2-14B-Text2Image
+
+The 14B model can be run similarly by changing the `--model_size` and `--dit_path` arguments.

--- a/documentations/post-training_text2image_cosmos_nemo_assets.md
+++ b/documentations/post-training_text2image_cosmos_nemo_assets.md
@@ -62,7 +62,7 @@ datasets/cosmos_nemo_assets_images/
 ├── metas/
 │   ├── *.txt
 ├── images/
-│   ├── *.mp4
+│   ├── *.jpg
 ├── t5_xxl/
 │   ├── *.pickle
 ```

--- a/documentations/post-training_text2image_cosmos_nemo_assets.md
+++ b/documentations/post-training_text2image_cosmos_nemo_assets.md
@@ -160,7 +160,7 @@ CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python examples/text2image.py \
   --model_size 2B \
   --dit_path "checkpoints/posttraining/text2image/2b_cosmos_nemo_assets/checkpoints/model/iter_000001000.pt" \
   --prompt "An image of sks teal robot." \
-  --save_path results/cosmos_nemo_assets/generated_video_teal_robot.jpg
+  --save_path output/cosmos_nemo_assets/generated_video_teal_robot.jpg
 ```
 
 See [documentations/inference_text2image.md](documentations/inference_text2image.md) for inference run details.

--- a/documentations/post-training_video2world.md
+++ b/documentations/post-training_video2world.md
@@ -105,6 +105,7 @@ predict2_video2world_training_2b_custom_data = dict(
         config=dict(
             pipe_config=dict(
                 ema=dict(enabled=True),     # enable EMA during training
+                prompt_refiner_config=dict(enabled=False),  # disable prompt refiner during training
                 guardrail_config=dict(enabled=False),   # disable guardrail during training
             ),
         )

--- a/documentations/post-training_video2world.md
+++ b/documentations/post-training_video2world.md
@@ -1,4 +1,4 @@
-# Predict2 Post-Training Guide
+# Predict2 Video2World Post-Training Guide
 
 This guide provides instructions on running post-training with Cosmos-Predict2 Video2World models.
 
@@ -36,7 +36,7 @@ For example, a custom dataset can be saved in a following structure.
 
 Dataset folder format:
 ```
-datasets/benchmark_train/custom_dataset/
+datasets/custom_video2world_dataset/
 ├── metas/
 │   ├── *.txt
 ├── videos/
@@ -48,11 +48,11 @@ datasets/benchmark_train/custom_dataset/
 
 After preparing `metas` and `videos` folders, run the following command to pre-compute T5-XXL embeddings.
 ```bash
-python -m scripts.get_t5_embeddings --dataset_path datasets/benchmark_train/custom_dataset/
+python -m scripts.get_t5_embeddings --dataset_path datasets/custom_video2world_dataset/
 ```
 This script will create `t5_xxl` folder under the dataset root where the T5-XXL embeddings are saved as `.pickle` files.
 ```
-datasets/benchmark_train/custom_dataset/
+datasets/custom_video2world_dataset/
 ├── metas/
 │   ├── *.txt
 ├── videos/
@@ -69,7 +69,7 @@ For example,
 ```python
 # custom dataset example
 example_video_dataset = L(Dataset)(
-    dataset_dir="datasets/benchmark_train/custom_dataset",
+    dataset_dir="datasets/custom_video2world_dataset",
     num_frames=93,
     video_size=(704, 1280),
 )
@@ -179,6 +179,8 @@ cosmos_predict2/configs/base/
 │   └── scheduler.py            # Learning rate scheduler configurations
 └── experiment/                 # Experiment-specific configurations
     ├── cosmos_nemo_assets.py   # Experiments with cosmos_nemo_assets
+    ├── agibot_head_center_fisheye_color.py  # Experiments with agibot_head_center_fisheye_color
+    ├── groot.py                # Experiments with groot
     └── utils.py                # Utility functions for experiments
 ```
 

--- a/documentations/post-training_video2world.md
+++ b/documentations/post-training_video2world.md
@@ -128,10 +128,10 @@ predict2_video2world_training_2b_custom_data = dict(
         lr=2 ** (-14.5),
     ),
     scheduler=dict(
-        warm_up_steps=[2_000],
-        cycle_lengths=[400_000],
+        warm_up_steps=[0],
+        cycle_lengths=[1_000],              # adjust considering max_iter
         f_max=[0.6],
-        f_min=[0.3],
+        f_min=[0.0],
     ),
 )
 ```

--- a/documentations/post-training_video2world_agibot_fisheye.md
+++ b/documentations/post-training_video2world_agibot_fisheye.md
@@ -249,7 +249,7 @@ CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python examples/video2world.py \
   --prompt "${PROMPT}" \
   --input_path "datasets/agibot_head_center_fisheye_color/val/task_327_episode_685393_window_0_frame_0-149.mp4" \
   --num_conditional_frmaes 1 \
-  --save_path results/agibot_head_center_fisheye_color/generated_video_2b.mp4
+  --save_path output/agibot_head_center_fisheye_color/generated_video_2b.mp4
 ```
 
 See [documentations/inference_video2world.md](documentations/inference_video2world.md) for inference run details.

--- a/documentations/post-training_video2world_agibot_fisheye.md
+++ b/documentations/post-training_video2world_agibot_fisheye.md
@@ -102,7 +102,7 @@ See the config `predict2_video2world_training_2b_agibot_head_center_fisheye_colo
 ```python
 # agibot_head_center_fisheye_color example
 example_video_dataset_agibot_head_center_fisheye_color = L(Dataset)(
-    dataset_dir="datasets/benchmark_train/agibot_head_center_fisheye_color",
+    dataset_dir="datasets/agibot_head_center_fisheye_color",
     num_frames=93,
     video_size=(704, 1280),
 )

--- a/documentations/post-training_video2world_cosmos_nemo_assets.md
+++ b/documentations/post-training_video2world_cosmos_nemo_assets.md
@@ -27,12 +27,12 @@ You must provide a folder containing a collection of videos in **MP4 format**, p
 You can use [nvidia/Cosmos-NeMo-Assets](https://huggingface.co/datasets/nvidia/Cosmos-NeMo-Assets) for post-training.
 
 ```bash
-mkdir -p datasets/benchmark_train/cosmos_nemo_assets/
+mkdir -p datasets/cosmos_nemo_assets/
 
 # This command will download the videos for physical AI
-huggingface-cli download nvidia/Cosmos-NeMo-Assets --repo-type dataset --local-dir datasets/benchmark_train/cosmos_nemo_assets/ --include "*.mp4*"
+huggingface-cli download nvidia/Cosmos-NeMo-Assets --repo-type dataset --local-dir datasets/cosmos_nemo_assets/ --include "*.mp4*"
 
-mv datasets/benchmark_train/cosmos_nemo_assets/nemo_diffusion_example_data datasets/benchmark_train/cosmos_nemo_assets/videos
+mv datasets/cosmos_nemo_assets/nemo_diffusion_example_data datasets/cosmos_nemo_assets/videos
 ```
 
 ### 1.2 Preprocessing the Data
@@ -41,12 +41,12 @@ Cosmos-NeMo-Assets comes with a single caption for 4 long videos.
 Run the following command to pre-compute T5-XXL embeddings for the video caption used for post-training:
 ```bash
 # The script will use the provided prompt, save the T5-XXL embeddings in pickle format.
-PYTHONPATH=$(pwd) python scripts/get_t5_embeddings_from_cosmos_nemo_assets.py --dataset_path datasets/benchmark_train/cosmos_nemo_assets --prompt "A video of sks teal robot."
+PYTHONPATH=$(pwd) python scripts/get_t5_embeddings_from_cosmos_nemo_assets.py --dataset_path datasets/cosmos_nemo_assets --prompt "A video of sks teal robot."
 ```
 
 Dataset folder format:
 ```
-datasets/benchmark_train/cosmos_nemo_assets/
+datasets/cosmos_nemo_assets/
 ├── metas/
 │   ├── *.txt
 ├── videos/
@@ -70,7 +70,7 @@ See the config `predict2_video2world_training_2b_cosmos_nemo_assets` defined in 
 ```python
 # Cosmos-NeMo-Assets example
 example_video_dataset_cosmos_nemo_assets = L(Dataset)(
-    dataset_dir="datasets/benchmark_train/cosmos_nemo_assets",
+    dataset_dir="datasets/cosmos_nemo_assets",
     num_frames=93,
     video_size=(704, 1280),
 )
@@ -147,7 +147,7 @@ Use `--dit_path` argument to specify the path to the post-trained checkpoint.
 ```bash
 CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python examples/video2world.py \
   --model_size 2B \
-  --dit_path "checkpoints/posttraining/video2world/predict2_video2world_training_2b_cosmos_nemo_assets/checkpoints/model/iter_000001000.pt" \
+  --dit_path "checkpoints/posttraining/video2world/2b_cosmos_nemo_assets/checkpoints/model/iter_000001000.pt" \
   --prompt "A video of sks teal robot." \
   --input_path "assets/video2world_cosmos_nemo_assets/output_Digit_Lift_movie.jpg" \
   --save_path results/cosmos_nemo_assets/generated_video_teal_robot.mp4

--- a/documentations/post-training_video2world_cosmos_nemo_assets.md
+++ b/documentations/post-training_video2world_cosmos_nemo_assets.md
@@ -150,7 +150,7 @@ CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python examples/video2world.py \
   --dit_path "checkpoints/posttraining/video2world/2b_cosmos_nemo_assets/checkpoints/model/iter_000001000.pt" \
   --prompt "A video of sks teal robot." \
   --input_path "assets/video2world_cosmos_nemo_assets/output_Digit_Lift_movie.jpg" \
-  --save_path results/cosmos_nemo_assets/generated_video_teal_robot.mp4
+  --save_path output/cosmos_nemo_assets/generated_video_teal_robot.mp4
 ```
 
 See [documentations/inference_video2world.md](documentations/inference_video2world.md) for inference run details.

--- a/documentations/post-training_video2world_gr00t.md
+++ b/documentations/post-training_video2world_gr00t.md
@@ -182,7 +182,7 @@ huggingface-cli download nvidia/EVAL-175 --repo-type dataset --local-dir dream_g
 ```bash
 python -m scripts.prepare_batch_input_json \
   --dataset_path dream_gen_benchmark/gr1_object/ \
-  --save_path results/dream_gen_benchmark/cosmos_predict2_14b_gr1_object/ \
+  --save_path output/dream_gen_benchmark/cosmos_predict2_14b_gr1_object/ \
   --output_path dream_gen_benchmark/gr1_object/batch_input.json
 ```
 

--- a/examples/video2world.py
+++ b/examples/video2world.py
@@ -29,7 +29,11 @@ from cosmos_predict2.configs.base.config_video2world import (
     PREDICT2_VIDEO2WORLD_PIPELINE_2B,
     PREDICT2_VIDEO2WORLD_PIPELINE_14B,
 )
-from cosmos_predict2.pipelines.video2world import _IMAGE_EXTENSIONS, _VIDEO_EXTENSIONS, Video2WorldPipeline
+from cosmos_predict2.pipelines.video2world import (
+    _IMAGE_EXTENSIONS,
+    _VIDEO_EXTENSIONS,
+    Video2WorldPipeline,
+)
 from imaginaire.utils import distributed, log, misc
 from imaginaire.utils.io import save_image_or_video
 
@@ -186,9 +190,10 @@ def setup_pipeline(args: argparse.Namespace, text_encoder=None):
     if hasattr(args, "dit_path") and args.dit_path:
         dit_path = args.dit_path
 
+    log.info(f"Using dit_path: {dit_path}")
+
     # Only set up text encoder path if no encoder is provided
     text_encoder_path = None if text_encoder is not None else "checkpoints/google-t5/t5-11b"
-    log.info(f"Using dit_path: {dit_path}")
     if text_encoder is not None:
         log.info("Using provided text encoder")
     else:

--- a/scripts/extract_images_from_videos.py
+++ b/scripts/extract_images_from_videos.py
@@ -1,0 +1,74 @@
+import argparse
+import os
+import shutil
+
+import imageio
+
+"""
+Example command:
+python -m scripts.extract_images_from_videos --input_dataset_dir datasets/benchmark_train/cosmos_nemo_assets --output_dataset_dir datasets/benchmark_train/cosmos_nemo_assets_images --stride 5
+"""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Extract frames from videos and save as images")
+    parser.add_argument(
+        "--input_dataset_dir", type=str, required=True, help="Path to the dataset directory containing videos"
+    )
+    parser.add_argument(
+        "--output_dataset_dir", type=str, required=True, help="Path to the dataset directory containing videos"
+    )
+    parser.add_argument("--stride", type=int, default=5, help="Stride for frame extraction (default: 5)")
+    return parser.parse_args()
+
+
+def main(args) -> None:
+    videos_dir = os.path.join(args.input_dataset_dir, "videos")
+    # Ensure the dataset directory exists
+    if not os.path.exists(videos_dir):
+        raise FileNotFoundError(f"Videos directory {videos_dir} does not exist.")
+
+    # Create output directory for images
+    output_images_dir = os.path.join(args.output_dataset_dir, "images")
+    os.makedirs(output_images_dir, exist_ok=True)
+
+    input_t5_dir = os.path.join(args.input_dataset_dir, "t5_xxl")
+    output_t5_dir = os.path.join(args.output_dataset_dir, "t5_xxl")
+    os.makedirs(output_t5_dir, exist_ok=True)
+
+    # Get the list of video files in the dataset directory
+    video_files = [filename for filename in os.listdir(videos_dir) if filename.endswith((".mp4"))]
+
+    global_count = 0
+    for video_file in video_files:
+        video_path = os.path.join(videos_dir, video_file)
+        print(f"Processing video: {video_path}")
+
+        video_basename = os.path.splitext(video_file)[0]
+        input_t5_path = os.path.join(input_t5_dir, f"{video_basename}.pickle")
+        # Read the video frames
+        reader = imageio.get_reader(video_path)
+
+        count = 0  # count for the saved images
+        for i, frame in enumerate(reader):
+            if i % args.stride == 0:  # Apply stride
+                # save a frame as an image
+                output_image_path = os.path.join(output_images_dir, f"{video_basename}_{count:08d}.jpg")
+                imageio.v3.imwrite(output_image_path, frame)
+
+                # copy video t5 embeddings
+                output_t5_path = os.path.join(output_t5_dir, f"{video_basename}_{count:08d}.pickle")
+                shutil.copy(input_t5_path, output_t5_path)
+
+                count += 1
+
+        global_count += count
+
+    print(f"Total frames saved: {global_count}")
+
+    return
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    main(args)

--- a/scripts/extract_images_from_videos.py
+++ b/scripts/extract_images_from_videos.py
@@ -1,12 +1,11 @@
 import argparse
 import os
-import shutil
 
 import imageio
 
 """
 Example command:
-python -m scripts.extract_images_from_videos --input_dataset_dir datasets/benchmark_train/cosmos_nemo_assets --output_dataset_dir datasets/benchmark_train/cosmos_nemo_assets_images --stride 5
+python -m scripts.extract_images_from_videos --input_dataset_dir datasets/cosmos_nemo_assets --output_dataset_dir datasets/cosmos_nemo_assets_images --stride 30
 """
 
 
@@ -18,7 +17,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--output_dataset_dir", type=str, required=True, help="Path to the dataset directory containing videos"
     )
-    parser.add_argument("--stride", type=int, default=5, help="Stride for frame extraction (default: 5)")
+    parser.add_argument("--stride", type=int, default=30, help="Stride for frame extraction (default: 30)")
     return parser.parse_args()
 
 
@@ -32,20 +31,15 @@ def main(args) -> None:
     output_images_dir = os.path.join(args.output_dataset_dir, "images")
     os.makedirs(output_images_dir, exist_ok=True)
 
-    input_t5_dir = os.path.join(args.input_dataset_dir, "t5_xxl")
-    output_t5_dir = os.path.join(args.output_dataset_dir, "t5_xxl")
-    os.makedirs(output_t5_dir, exist_ok=True)
-
     # Get the list of video files in the dataset directory
     video_files = [filename for filename in os.listdir(videos_dir) if filename.endswith((".mp4"))]
 
     global_count = 0
     for video_file in video_files:
         video_path = os.path.join(videos_dir, video_file)
-        print(f"Processing video: {video_path}")
+        print(f"Extracting frames from video: {video_path}")
 
         video_basename = os.path.splitext(video_file)[0]
-        input_t5_path = os.path.join(input_t5_dir, f"{video_basename}.pickle")
         # Read the video frames
         reader = imageio.get_reader(video_path)
 
@@ -55,10 +49,6 @@ def main(args) -> None:
                 # save a frame as an image
                 output_image_path = os.path.join(output_images_dir, f"{video_basename}_{count:08d}.jpg")
                 imageio.v3.imwrite(output_image_path, frame)
-
-                # copy video t5 embeddings
-                output_t5_path = os.path.join(output_t5_dir, f"{video_basename}_{count:08d}.pickle")
-                shutil.copy(input_t5_path, output_t5_path)
 
                 count += 1
 

--- a/scripts/get_t5_embeddings_from_cosmos_nemo_assets.py
+++ b/scripts/get_t5_embeddings_from_cosmos_nemo_assets.py
@@ -22,7 +22,7 @@ import numpy as np
 from cosmos_predict2.auxiliary.text_encoder import CosmosT5TextEncoder
 
 """example command
-python -m scripts.get_t5_embeddings_from_cosmos_nemo_assets --dataset_path datasets/benchmark_train/cosmos_nemo_assets
+python -m scripts.get_t5_embeddings_from_cosmos_nemo_assets --dataset_path datasets/cosmos_nemo_assets
 """
 
 
@@ -31,7 +31,7 @@ def parse_args() -> argparse.ArgumentParser:
     parser.add_argument(
         "--dataset_path",
         type=str,
-        default="datasets/benchmark_train/cosmos_nemo_assets",
+        default="datasets/cosmos_nemo_assets",
         help="Root path to the dataset",
     )
     parser.add_argument("--max_length", type=int, default=512, help="Maximum length of the text embedding")
@@ -39,20 +39,29 @@ def parse_args() -> argparse.ArgumentParser:
     parser.add_argument(
         "--cache_dir", type=str, default="checkpoints/google-t5/t5-11b", help="Directory to cache the T5 model"
     )
+    parser.add_argument("--is_image", action="store_true", help="Set if the dataset is image-based")
     return parser.parse_args()
 
 
 def main(args) -> None:
+    images_dir = os.path.join(args.dataset_path, "images")
     videos_dir = os.path.join(args.dataset_path, "videos")
 
     # Cosmos-NeMo-Assets come with videos only. A prompt is provided as an argument.
     metas_dir = os.path.join(args.dataset_path, "metas")
     os.makedirs(metas_dir, exist_ok=True)
-    metas_list = [
-        os.path.join(metas_dir, filename.replace(".mp4", ".txt"))
-        for filename in sorted(os.listdir(videos_dir))
-        if filename.endswith(".mp4")
-    ]
+    if args.is_image:
+        metas_list = [
+            os.path.join(metas_dir, filename.replace(".jpg", ".txt"))
+            for filename in sorted(os.listdir(images_dir))
+            if filename.endswith(".jpg")
+        ]
+    else:
+        metas_list = [
+            os.path.join(metas_dir, filename.replace(".mp4", ".txt"))
+            for filename in sorted(os.listdir(videos_dir))
+            if filename.endswith(".mp4")
+        ]
 
     # Write txt files to match other dataset formats.
     for meta_filename in metas_list:
@@ -66,27 +75,26 @@ def main(args) -> None:
     # Initialize T5
     encoder = CosmosT5TextEncoder(cache_dir=args.cache_dir, local_files_only=True)
 
+    # Compute T5 embeddings
+    print(f"Computing T5 embeddings for the prompt: {args.prompt}")
+    max_length = args.max_length
+    encoded_text, mask_bool = encoder.encode_prompts(
+        args.prompt, max_length=max_length, return_mask=True
+    )  # list of np.ndarray in (len, 1024)
+    attn_mask = mask_bool.long()
+    lengths = attn_mask.sum(dim=1).cpu()
+
+    encoded_text = encoded_text.cpu().numpy().astype(np.float16)
+
+    # trim zeros to save space
+    encoded_text = [encoded_text[batch_id][: lengths[batch_id]] for batch_id in range(encoded_text.shape[0])]
+
+    print(f"Saving T5 embeddings to {t5_xxl_dir}")
     for meta_filename in metas_list:
         t5_xxl_filename = os.path.join(t5_xxl_dir, os.path.basename(meta_filename).replace(".txt", ".pickle"))
         if os.path.exists(t5_xxl_filename):
             # Skip if the file already exists
             continue
-
-        with open(meta_filename, "r") as fp:
-            prompt = fp.read().strip()
-
-        # Compute T5 embeddings
-        max_length = args.max_length
-        encoded_text, mask_bool = encoder.encode_prompts(
-            prompt, max_length=max_length, return_mask=True
-        )  # list of np.ndarray in (len, 1024)
-        attn_mask = mask_bool.long()
-        lengths = attn_mask.sum(dim=1).cpu()
-
-        encoded_text = encoded_text.cpu().numpy().astype(np.float16)
-
-        # trim zeros to save space
-        encoded_text = [encoded_text[batch_id][: lengths[batch_id]] for batch_id in range(encoded_text.shape[0])]
 
         # Save T5 embeddings as pickle file
         with open(t5_xxl_filename, "wb") as fp:


### PR DESCRIPTION
* text2image post-training enabled
  * text2image pipeline updated & model added.
  * Example training provided with cosmos_nemo_assets by extracting video frames as training data.
  * Registered mock validation dataloaders with compatible resolutions.
* Disabled prompt refiner for video2world training.
  * It was enabled by default by other updates from pipeline configs.
* Data preprocessing code updated
  * Made T5 computation code simpler.
  * Provided preprocessing script for cosmos_nemo_assets_image.
* Misc. style unification across text2image & video2world