### PR TITLE
Attention fixes, cuda graphs for V2W

### DIFF
--- a/cosmos_predict2/models/video2world_dit.py
+++ b/cosmos_predict2/models/video2world_dit.py
@@ -36,6 +36,7 @@ class MinimalV1LVGDiT(MiniTrainDIT):
         fps: Optional[torch.Tensor] = None,
         padding_mask: Optional[torch.Tensor] = None,
         data_type: Optional[DataType] = DataType.VIDEO,
+        use_cuda_graphs: bool = False,
         **kwargs,
     ) -> torch.Tensor | List[torch.Tensor] | Tuple[torch.Tensor, List[torch.Tensor]]:
         del kwargs
@@ -54,4 +55,5 @@ class MinimalV1LVGDiT(MiniTrainDIT):
             fps=fps,
             padding_mask=padding_mask,
             data_type=data_type,
+            use_cuda_graphs=use_cuda_graphs,
         )

--- a/examples/text2image.py
+++ b/examples/text2image.py
@@ -186,9 +186,12 @@ def process_single_generation(
         )
         if benchmark and i > 0:
             torch.cuda.synchronize()
-            time_sum += time.time() - start_time
+            elapsed = time.time() - start_time
+            time_sum += elapsed
+            log.info(f"[iter {i} / {num_repeats - 1}] Generation time: {elapsed:.1f} seconds.")
     if benchmark:
-        log.critical(f"The benchmarked generation time for Text2ImagePipeline is {time_sum / 3} seconds.")
+        time_avg = time_sum / (num_repeats - 1)
+        log.critical(f"The benchmarked generation time for Text2ImagePipeline is {time_avg:.1f} seconds.")
 
     if image is not None:
         # save the generated image

--- a/examples/text2world.py
+++ b/examples/text2world.py
@@ -241,6 +241,7 @@ def generate_videos(video2world_pipe: Video2WorldPipeline, batch_items: list, ar
             guidance=args.guidance,
             seed=args.seed,
             benchmark=args.benchmark,
+            use_cuda_graphs=args.use_cuda_graphs,
         )
 
         # Clean up the temporary image file


### PR DESCRIPTION
Adds CUDA graphs for Video2World inference, and fixes a few things in `attention.py`:

There is no use case for varlen, but it was previously using the varlen API, and the extra ops required to run it broke CUDA graphs, and added around 3-5% overhead E2E!
We're now removing `q_len` and `k_len` completely.

Also annotating a few more places in attention, and added a dtype check.

Also logs benchmark times every iter just as a sign of life, since they can take a while especially when doing 14B, 720p, 16fps.