### PR TITLE
Disable guardrail and prompt upsampler by default

### DIFF
--- a/documentations/inference_text2image.md
+++ b/documentations/inference_text2image.md
@@ -100,7 +100,7 @@ Performance optimization:
 - `--benchmark`: Run in benchmark mode to measure average generation time
 
 Content safety:
-- `--disable_guardrail`: Disable guardrail checks on prompts (by default, guardrails are enabled to filter harmful content)
+- `--enable_guardrail`: Enable guardrail checks against harmful content in prompts
 
 > **Note**: Text2Image runs on a single GPU and does not support multi-GPU inference. For multi-GPU video generation, use [Text2World](inference_text2world.md) or [Video2World](inference_video2world.md) pipelines.
 

--- a/documentations/inference_text2world.md
+++ b/documentations/inference_text2world.md
@@ -108,9 +108,7 @@ torchrun --nproc_per_node=${NUM_GPUS} -m examples.text2world \
     --model_size 2B \
     --prompt "${PROMPT}" \
     --save_path output/text2world_2b_${NUM_GPUS}gpu.mp4 \
-    --num_gpus ${NUM_GPUS} \
-    --disable_guardrail \
-    --disable_prompt_refiner
+    --num_gpus ${NUM_GPUS}
 ```
 
 This distributes the computation across multiple GPUs for the video generation phase (Video2World), with each GPU processing a subset of the video frames. The image generation phase (Text2Image) still runs on a single GPU.
@@ -163,8 +161,8 @@ Batch processing:
 - `--batch_input_json`: Path to JSON file containing batch inputs, where each entry should have 'prompt' and 'output_video' fields
 
 Content safety and controls:
-- `--disable_guardrail`: Disable guardrail checks on prompts (by default, guardrails are enabled to filter harmful content)
-- `--disable_prompt_refiner`: Disable prompt refiner that enhances short prompts (by default, the prompt refiner is enabled)
+- `--enable_guardrail`: Enable guardrail checks against harmful content in prompts
+- `--enable_prompt_refiner`: Enable prompt refiner that enhances short prompts
 - `--offload_guardrail`: Offload guardrail to CPU to save GPU memory
 - `--offload_prompt_refiner`: Offload prompt refiner to CPU to save GPU memory
 

--- a/documentations/inference_video2world.md
+++ b/documentations/inference_video2world.md
@@ -173,14 +173,14 @@ python -m examples.video2world \
     --save_path output/video2world_2b_with_prompt_refiner.mp4
 ```
 
-The prompt refiner is enabled by default. To disable it, use the `--disable_prompt_refiner` flag:
+The prompt refiner is disabled by default. To enable it, use the `--enable_prompt_refiner` flag:
 ```bash
-# Run video2world generation without prompt refinement
+# Run video2world generation with prompt refinement
 python -m examples.video2world \
     --model_size 2B \
     --input_path assets/video2world/input0.jpg \
     --prompt "${PROMPT}" \
-    --disable_prompt_refiner \
+    --enable_prompt_refiner \
     --save_path output/video2world_2b_without_prompt_refiner.mp4
 ```
 
@@ -239,7 +239,6 @@ python -m examples.video2world_bestofn \
     --prompt "${PROMPT}" \
     --num_generations 4 \
     --num_critic_trials 5 \
-    --disable_guardrail \
     --save_path output/rejection_sampling_demo
 ```
 
@@ -278,9 +277,7 @@ PYTHONPATH=. torchrun --nproc_per_node=${NUM_GPUS} examples/video2world_lvg.py \
     --input_path assets/video2world_lvg/example_input.jpg \
     --prompt "${PROMPT}" \
     --save_path output/video2world_2b_lvg_example1.mp4 \
-    --num_gpus ${NUM_GPUS} \
-    --disable_guardrail \
-    --disable_prompt_refiner
+    --num_gpus ${NUM_GPUS}
 ```
 
 Example output is included at `assets/video2world_lvg/example_output.mp4`.
@@ -325,8 +322,8 @@ Batch processing:
 - `--batch_input_json`: Path to JSON file containing batch inputs, where each entry should have 'input_video', 'prompt', and 'output_video' fields
 
 Content safety and controls:
-- `--disable_guardrail`: Disable guardrail checks on prompts (by default, guardrails are enabled to filter harmful content)
-- `--disable_prompt_refiner`: Disable prompt refiner that enhances short prompts (by default, the prompt refiner is enabled)
+- `--enable_guardrail`: Enable guardrail checks against harmful content in prompts
+- `--enable_prompt_refiner`: Enable prompt refiner that enhances short prompts
 
 GPU memory controls:
 - `--offload_guardrail`: Offload guardrail to CPU to save GPU memory

--- a/documentations/post-training_video2world_action.md
+++ b/documentations/post-training_video2world_action.md
@@ -90,7 +90,5 @@ CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python examples/action_video2world.py 
   --num_conditional_frames 1 \
   --save_path output/generated_video.mp4 \
   --guidance 0 \
-  --seed 0 \
-  --disable_guardrail \
-  --disable_prompt_refiner
+  --seed 0
 ```

--- a/documentations/post-training_video2world_gr00t.md
+++ b/documentations/post-training_video2world_gr00t.md
@@ -191,10 +191,8 @@ python -m scripts.prepare_batch_input_json \
 python -m examples.video2world_gr00t \
   --model_size 14B \
   --gr00t_variant gr1 \
-  --batch_input_json dream_gen_benchmark/gr1_object/batch_input.json \
-  --disable_guardrail
+  --batch_input_json dream_gen_benchmark/gr1_object/batch_input.json
 ```
-* Note: For full evaluation without missing videos, it's better to turn off the guardrail checks (add `--disable_guardrail` to the command) to make sure all the videos are generated.
 * See [documentations/inference_video2world.md](documentations/inference_video2world.md) for inference run details.
 
 ## 5. Inference with Cosmos-Reason1 Rejection Sampling
@@ -211,6 +209,5 @@ torchrun --nproc_per_node=8 --master_port=12341 \
   --num_gpus 8 \
   --num_generations 4 \
   --prompt_prefix "" \
-  --disable_guardrail \
   --save_path output/best-of-n-gr00t-gr1
 ```

--- a/examples/action_video2world.py
+++ b/examples/action_video2world.py
@@ -102,9 +102,9 @@ def parse_args() -> argparse.Namespace:
         default=1,
         help="Number of GPUs to use for context parallel inference (should be a divisor of the total frames)",
     )
-    parser.add_argument("--disable_guardrail", action="store_true", help="Disable guardrail checks on prompts")
+    parser.add_argument("--enable_guardrail", action="store_true", help="Enable guardrail checks on prompts")
     parser.add_argument(
-        "--disable_prompt_refiner", action="store_true", help="Disable prompt refiner that enhances short prompts"
+        "--enable_prompt_refiner", action="store_true", help="Enable prompt refiner that enhances short prompts"
     )
     return parser.parse_args()
 
@@ -137,13 +137,13 @@ def setup_pipeline(args: argparse.Namespace):
         parallel_state.initialize_model_parallel(context_parallel_size=args.num_gpus)
         log.info(f"Context parallel group initialized with {args.num_gpus} GPUs")
 
-    # Disable guardrail if requested
-    if args.disable_guardrail:
+    # Enable guardrail if requested
+    if not args.enable_guardrail:
         log.warning("Guardrail checks are disabled")
         config.guardrail_config.enabled = False
 
-    # Disable prompt refiner if requested
-    if args.disable_prompt_refiner:
+    # Enable prompt refiner if requested
+    if not args.enable_prompt_refiner:
         log.warning("Prompt refiner is disabled")
         config.prompt_refiner_config.enabled = False
 

--- a/examples/text2image.py
+++ b/examples/text2image.py
@@ -67,7 +67,7 @@ def parse_args() -> argparse.Namespace:
         help="Path to save the generated image (include file extension)",
     )
     parser.add_argument("--use_cuda_graphs", action="store_true", help="Use CUDA Graphs for the inference.")
-    parser.add_argument("--disable_guardrail", action="store_true", help="Disable guardrail checks on prompts")
+    parser.add_argument("--enable_guardrail", action="store_true", help="Enable guardrail checks on prompts")
     parser.add_argument("--offload_guardrail", action="store_true", help="Offload guardrail to CPU to save GPU memory")
     parser.add_argument(
         "--benchmark",
@@ -88,8 +88,8 @@ def setup_pipeline(args: argparse.Namespace) -> Text2ImagePipeline:
     else:
         raise ValueError("Invalid model size. Choose either '2B' or '14B'.")
 
-    # Disable guardrail if requested
-    if args.disable_guardrail:
+    # Enable guardrail if requested
+    if not args.enable_guardrail:
         log.warning("Guardrail checks are disabled")
         config.guardrail_config.enabled = False
     config.guardrail_config.offload_model_to_cpu = args.offload_guardrail

--- a/examples/text2world.py
+++ b/examples/text2world.py
@@ -73,7 +73,7 @@ def parse_args() -> argparse.Namespace:
         default="output/generated_video.mp4",
         help="Path to save the generated video (include file extension)",
     )
-    parser.add_argument("--disable_guardrail", action="store_true", help="Disable guardrail checks on prompts")
+    parser.add_argument("--enable_guardrail", action="store_true", help="Enable guardrail checks on prompts")
     parser.add_argument(
         "--num_gpus",
         type=int,
@@ -113,7 +113,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--guidance", type=float, default=7, help="Guidance value for video generation")
     parser.add_argument("--offload_guardrail", action="store_true", help="Offload guardrail to CPU to save GPU memory")
     parser.add_argument(
-        "--disable_prompt_refiner", action="store_true", help="Disable prompt refiner that enhances short prompts"
+        "--enable_prompt_refiner", action="store_true", help="Enable prompt refiner that enhances short prompts"
     )
     parser.add_argument(
         "--offload_prompt_refiner", action="store_true", help="Offload prompt refiner to CPU to save GPU memory"

--- a/examples/video2world.py
+++ b/examples/video2world.py
@@ -146,10 +146,10 @@ def parse_args() -> argparse.Namespace:
         default=1,
         help="Number of GPUs to use for context parallel inference (should be a divisor of the total frames)",
     )
-    parser.add_argument("--disable_guardrail", action="store_true", help="Disable guardrail checks on prompts")
+    parser.add_argument("--enable_guardrail", action="store_true", help="Enable guardrail checks on prompts")
     parser.add_argument("--offload_guardrail", action="store_true", help="Offload guardrail to CPU to save GPU memory")
     parser.add_argument(
-        "--disable_prompt_refiner", action="store_true", help="Disable prompt refiner that enhances short prompts"
+        "--enable_prompt_refiner", action="store_true", help="Enable prompt refiner that enhances short prompts"
     )
     parser.add_argument(
         "--offload_prompt_refiner", action="store_true", help="Offload prompt refiner to CPU to save GPU memory"
@@ -221,14 +221,14 @@ def setup_pipeline(args: argparse.Namespace, text_encoder=None):
             else:
                 log.info(f"Using existing context parallel group with {current_cp_size} GPUs")
 
-    # Disable guardrail if requested
-    if args.disable_guardrail:
+    # Enable guardrail if requested
+    if not args.enable_guardrail:
         log.warning("Guardrail checks are disabled")
         config.guardrail_config.enabled = False
     config.guardrail_config.offload_model_to_cpu = args.offload_guardrail
 
-    # Disable prompt refiner if requested
-    if args.disable_prompt_refiner:
+    # Enable prompt refiner if requested
+    if not args.enable_prompt_refiner:
         log.warning("Prompt refiner is disabled")
         config.prompt_refiner_config.enabled = False
     config.prompt_refiner_config.offload_model_to_cpu = args.offload_prompt_refiner

--- a/examples/video2world_bestofn.py
+++ b/examples/video2world_bestofn.py
@@ -264,10 +264,10 @@ def parse_args():
         default=1,
         help="Number of GPUs to use for context parallel inference (should be a divisor of the total frames)",
     )
-    parser.add_argument("--disable_guardrail", action="store_true", help="Disable guardrail checks on prompts")
+    parser.add_argument("--enable_guardrail", action="store_true", help="Enable guardrail checks on prompts")
     parser.add_argument("--offload_guardrail", action="store_true", help="Offload guardrail to CPU to save GPU memory")
     parser.add_argument(
-        "--disable_prompt_refiner", action="store_true", help="Disable prompt refiner that enhances short prompts"
+        "--enable_prompt_refiner", action="store_true", help="Enable prompt refiner that enhances short prompts"
     )
     parser.add_argument(
         "--offload_prompt_refiner", action="store_true", help="Offload prompt refiner to CPU to save GPU memory"

--- a/examples/video2world_gr00t.py
+++ b/examples/video2world_gr00t.py
@@ -104,7 +104,7 @@ def parse_args() -> argparse.Namespace:
         help="Number of GPUs to use for context parallel inference (should be a divisor of the total frames)",
     )
     parser.add_argument(
-        "--disable_guardrail",
+        "--enable_guardrail",
         action="store_true",
         help="Disable guardrail checks on prompts",
     )
@@ -154,8 +154,8 @@ def setup_pipeline(args: argparse.Namespace):
         parallel_state.initialize_model_parallel(context_parallel_size=args.num_gpus)
         log.info(f"Context parallel group initialized with {args.num_gpus} GPUs")
 
-    # Disable guardrail if requested
-    if args.disable_guardrail:
+    # Enable guardrail if requested
+    if not args.enable_guardrail:
         log.warning("Guardrail checks are disabled")
         config.guardrail_config.enabled = False
 

--- a/examples/video2world_lvg.py
+++ b/examples/video2world_lvg.py
@@ -139,9 +139,9 @@ def parse_args() -> argparse.Namespace:
         default=1,
         help="Number of GPUs to use for context parallel inference (should be a divisor of the total frames)",
     )
-    parser.add_argument("--disable_guardrail", action="store_true", help="Disable guardrail checks on prompts")
+    parser.add_argument("--enable_guardrail", action="store_true", help="Enable guardrail checks on prompts")
     parser.add_argument(
-        "--disable_prompt_refiner", action="store_true", help="Disable prompt refiner that enhances short prompts"
+        "--enable_prompt_refiner", action="store_true", help="Enable prompt refiner that enhances short prompts"
     )
     return parser.parse_args()
 
@@ -176,13 +176,13 @@ def setup_pipeline(args: argparse.Namespace):
         parallel_state.initialize_model_parallel(context_parallel_size=args.num_gpus)
         log.info(f"Context parallel group initialized with {args.num_gpus} GPUs")
 
-    # Disable guardrail if requested
-    if args.disable_guardrail:
+    # Enable guardrail if requested
+    if not args.enable_guardrail:
         log.warning("Guardrail checks are disabled")
         config.guardrail_config.enabled = False
 
-    # Disable prompt refiner if requested
-    if args.disable_prompt_refiner:
+    # Enable prompt refiner if requested
+    if not args.enable_prompt_refiner:
         log.warning("Prompt refiner is disabled")
         config.prompt_refiner_config.enabled = False
 


### PR DESCRIPTION
These two should be optional, especially prompt upsampler. They consume memory, and even on datacenter class cards with lots of memory they result in OOMs, or need offloading.