### PR TITLE
Minor doc fixes

### DIFF
--- a/cosmos_predict2/pipelines/video2world.py
+++ b/cosmos_predict2/pipelines/video2world.py
@@ -22,6 +22,7 @@ import torch
 import torchvision
 from einops import rearrange
 from megatron.core import parallel_state
+from tqdm import tqdm
 from PIL import Image
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.fsdp import fully_shard
@@ -887,7 +888,7 @@ class Video2WorldPipeline(BasePipeline):
 
         x0_prev: torch.Tensor | None = None
 
-        for i, _ in enumerate(scheduler.timesteps):
+        for i, _ in enumerate(tqdm(scheduler.timesteps, desc="Generating world", leave=False)):
             # Current noise level (sigma_t).
             sigma_t = scheduler.sigmas[i].to(sample.device, dtype=torch.float32)
 

--- a/documentations/inference_text2image.md
+++ b/documentations/inference_text2image.md
@@ -94,10 +94,12 @@ Input and output parameters:
 Model selection:
 - `--model_size`: Size of the model to use (choices: "2B", "14B", default: "2B")
 
-Performance optimization:
+Generation parameters:
 - `--seed`: Random seed for reproducible results (default: 0)
-- `--use_cuda_graphs`: Use CUDA Graphs for inference acceleration
-- `--benchmark`: Run in benchmark mode to measure average generation time
+
+Performance optimization parameters:
+- `--use_cuda_graphs`: Use CUDA Graphs to accelerate DiT inference.
+- `--benchmark`: Run in benchmark mode to measure average generation time.
 
 Content safety:
 - `--disable_guardrail`: Disable guardrail checks on prompts (by default, guardrails are enabled to filter harmful content)

--- a/documentations/inference_text2world.md
+++ b/documentations/inference_text2world.md
@@ -143,10 +143,12 @@ Output parameters:
 Generation parameters:
 - `--guidance`: Classifier-free guidance scale for video generation (default: 7.0)
 - `--seed`: Random seed for reproducibility (default: 0)
-- `--benchmark`: Run in benchmark mode to measure average generation time
+
+Performance optimization parameters:
+- `--use_cuda_graphs`: Use CUDA Graphs to accelerate DiT inference.
+- `--benchmark`: Run in benchmark mode to measure average generation time.
 
 Text2Image phase parameters:
-- `--use_cuda_graphs`: Use CUDA Graphs for Text2Image inference acceleration
 - `--resolution`: Resolution for text2image generation (choices: "480", "720", default: "720")
 - `--fps`: FPS for video2world generation (choices: 10, 16, default: 16)
 

--- a/documentations/inference_video2world.md
+++ b/documentations/inference_video2world.md
@@ -316,6 +316,10 @@ Generation parameters:
 - `--seed`: Random seed for reproducibility (default: 0)
 - `--num_gpus`: Number of GPUs to use for context parallel inference in the video generation phase (default: 1)
 
+Performance parameters:
+- `--use_cuda_graphs`: Use CUDA Graphs to accelerate DiT inference.
+- `--benchmark`: Run in benchmark mode to measure average generation time.
+
 Multi-GPU inference:
 - For multi-GPU inference, use `torchrun --nproc_per_node=$NUM_GPUS examples/video2world.py ...`
 - Both `--nproc_per_node` (for torchrun) and `--num_gpus` (for the script) must be set to the same value

--- a/documentations/performance.md
+++ b/documentations/performance.md
@@ -40,6 +40,8 @@ The following table shows generation times across different NVIDIA GPU hardware:
 
 Note: (OOM) indicates "Out of Memory" - the model is too large to run on that GPU.
 
+Note: Video2World was run with 480p resolution and at 16 FPS.
+
 ### Post-training performance
 
 Review the [AgiBot-Fisheye](post-training_video2world_agibot_fisheye.md) post-training example, which contains performance numbers on different GPUs.


### PR DESCRIPTION
Makes docs more consistent in how perf-related flags are introduced, adds CUDA graphs flags to missing docs, and adds clarification on perf numbers.

Also adds tqdm progress bar to V2W for consistency with T2I and other tasks.