### PR TITLE
empty cuda cache in checkpoint loading process

### DIFF
--- a/cosmos_predict2/checkpointer.py
+++ b/cosmos_predict2/checkpointer.py
@@ -193,6 +193,7 @@ class Checkpointer:
 
         # Load checkpoint.
         if latest_checkpoint_file is not None:
+            torch.cuda.empty_cache()
             state_dicts_paths = {
                 "model": model_checkpoint_path,
                 "optim": optimizer_checkpoint_path,
@@ -252,6 +253,7 @@ class Checkpointer:
                 model.pipe.apply_cp()
             else:
                 model.load_state_dict(state_dicts_to_load["model"], strict=self.strict_resume)
+            torch.cuda.empty_cache()
             if resume or only_resume_scheduler:
                 iteration = state_dicts_to_load["trainer"]["iteration"]
                 assert scheduler


### PR DESCRIPTION
* We have reports that when we resume 14B video2world model post-training, it goes OOM when loading checkpoints. #59 
* I don't see specific reasons why it would go OOM. The loaded checkpoint stays in CPU until they are loaded to the initialized weights. The required GPU memory for the loading operation shouldn't be large.
* I tried several different commits from the git history, however, I couldn't reproduce the error.
* Regardless, I witnessed emptying cache before loading the checkpoint can reduce the cached memory by ~25 GB, hopefully it could resolve the issue. The default caching behavior could be different on each machine.