### PR TITLE
Cosmos-Predict2 + NATTEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ We visualize the architecture of Cosmos-Predict2 in the following figure.
 </p>
 
 ## News
-* 2025-07-10: We released [Predict2 + NATTEN](documentations/performance.md#sparse-attention-powered-by-natten), bringing up to 2.6X end-to-end inference speedup with sparse attention.
+* 2025-07-10: We released [Predict2 + NATTEN](documentations/performance.md#sparse-attention-powered-by-natten), bringing up to 2.6X end-to-end inference speedup with sparse attention ([Video](https://www.youtube.com/watch?v=o396JZsz4V4)).
 * 2025-06-11: We released post-training and inference code, along with model weights. For a code walkthrough, please see this [video](https://www.youtube.com/watch?v=ibnVm6hPtxA).
 
 ## Models

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ We visualize the architecture of Cosmos-Predict2 in the following figure.
 </p>
 
 ## News
+* 2025-07-10: We released Predict2 + NATTEN, bringing up to 2.6X end-to-end inference speedup with sparse attention.
 * 2025-06-11: We released post-training and inference code, along with model weights. For a code walkthrough, please see this [video](https://www.youtube.com/watch?v=ibnVm6hPtxA).
 
 ## Models

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ We visualize the architecture of Cosmos-Predict2 in the following figure.
 </p>
 
 ## News
-* 2025-07-10: We released Predict2 + NATTEN, bringing up to 2.6X end-to-end inference speedup with sparse attention.
+* 2025-07-10: We released [Predict2 + NATTEN](documentations/performance.md#sparse-attention-powered-by-natten), bringing up to 2.6X end-to-end inference speedup with sparse attention.
 * 2025-06-11: We released post-training and inference code, along with model weights. For a code walkthrough, please see this [video](https://www.youtube.com/watch?v=ibnVm6hPtxA).
 
 ## Models

--- a/cosmos_predict2/configs/base/config_natten.py
+++ b/cosmos_predict2/configs/base/config_natten.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# This file holds neighborhood attention [1] parameters for the 2B and 14B Video2World
+# models. These parameters were selected from a small pool of varying attention patterns,
+# some simply local (strided) sliding window attention [1,4], and some sparse-global dilated sliding
+# window attention [2]. All patterns in the pool were derived using NATTENSim [4] and confirmed to
+# be highly or fully block-sparse.
+# The selection process was a simple profiling with layer granularity. Attention head granularity
+# (similar to Hydra-NA [6]) is left as future work.
+#
+# These variants can bring 1.7X to 2.6X speedup to 720p Video2World inference depending on
+# frame-rate, model size, and GPU architecture. The baselines are Flash Attention 3 [5] and cuDNN
+# Attention, which are the state of the art for the Hopper and Blackwell architectures respectively.
+# NATTEN's Hopper and Blackwell FNA [3] kernels are built on top of CUTLASS's FMHA kernels, which
+# achieve similar performance to the baselines.
+#
+# For more information refer to Generalized Neighborhood Attention [4], and the NATTEN project (natten.org).
+#
+#  [1] Neighborhood Attention Transformer: https://arxiv.org/abs/2204.07143
+#  [2] Dilated Neighborhood Attention Transformer: https://arxiv.org/abs/2209.15001
+#  [3] Faster Neighborhood Attention: https://arxiv.org/abs/2403.04690
+#  [4] Generalized Neighborhood Attention: https://arxiv.org/abs/2504.16922
+#  [5] Flash Attention 3: https://arxiv.org/abs/2407.08608
+#  [6] Efficient Image Generation with Variadic Attention Heads: https://arxiv.org/abs/2211.05770
+#
+
+# 2B Configuration:
+# Layers 0, 1: 98% sparsity, sparse global (max dilation) along H and W
+# Layers 2, 5, 10: 95% sparsity, sparse global (max dilation) along W
+# Layers 3, 4, 6, 7, 8, 9, 27: 92% sparsity, local
+# Layers 11-22, 24-26: 77% sparsity, local
+# Layer 23: 55% sparsity
+# No global self attention layers.
+#
+# Expected 1.9 – 2.6X End-to-End speedup depending on FPS, device arch.
+#
+PREDICT2_VIDEO2WORLD_NET_2B_NATTEN_PARAMETERS = [
+    {"window_size": (-1, 4, 16), "dilation": (1, 11, 5), "base_size": (-1, 44, 80)},  # layer 0
+    {"window_size": (-1, 4, 16), "dilation": (1, 11, 5), "base_size": (-1, 44, 80)},  # layer 1
+    {"window_size": (-1, 12, 16), "stride": (1, 4, 1), "dilation": (1, 1, 5), "base_size": (-1, 44, 80)},  # layer 2
+    {"window_size": (-1, 12, 24), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 3
+    {"window_size": (-1, 12, 24), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 4
+    {"window_size": (-1, 12, 16), "stride": (1, 4, 1), "dilation": (1, 1, 5), "base_size": (-1, 44, 80)},  # layer 5
+    {"window_size": (-1, 12, 24), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 6
+    {"window_size": (-1, 12, 24), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 7
+    {"window_size": (-1, 12, 24), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 8
+    {"window_size": (-1, 12, 24), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 9
+    {"window_size": (-1, 12, 16), "stride": (1, 4, 1), "dilation": (1, 1, 5), "base_size": (-1, 44, 80)},  # layer 10
+    {"window_size": (-1, 20, 40), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 11
+    {"window_size": (-1, 20, 40), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 12
+    {"window_size": (-1, 20, 40), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 13
+    {"window_size": (-1, 20, 40), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 14
+    {"window_size": (-1, 20, 40), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 15
+    {"window_size": (-1, 20, 40), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 16
+    {"window_size": (-1, 20, 40), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 17
+    {"window_size": (-1, 20, 40), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 18
+    {"window_size": (-1, 20, 40), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 19
+    {"window_size": (-1, 20, 40), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 20
+    {"window_size": (-1, 20, 40), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 21
+    {"window_size": (-1, 20, 40), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 22
+    {"window_size": (-1, 28, 56), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 23
+    {"window_size": (-1, 20, 40), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 24
+    {"window_size": (-1, 20, 40), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 25
+    {"window_size": (-1, 20, 40), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 26
+    {"window_size": (-1, 12, 24), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 27
+]
+
+
+
+# 14B Configuration:
+# Layers 0-10: 98% sparsity, sparse global (max dilation) along H and W
+# Layers 11, 12: 95% sparsity, sparse global (max dilation) along W
+# Layers 13-22: 92% sparsity, local
+# Layers 23, 25, 29, 30, 33, 35: 77% sparsity, local
+# Layers 24, 26, 28, 31, 32, 34: 55% sparsity
+# Layer 27: 0% sparsity (self attn)
+# 1 global self attention layer.
+#
+# Expected 1.7 – 2.1X End-to-End speedup depending on FPS, device arch.
+#
+PREDICT2_VIDEO2WORLD_NET_14B_NATTEN_PARAMETERS = [
+    {"window_size": (-1, 4, 16), "dilation": (1, 11, 5), "base_size": (-1, 44, 80)},  # layer 0
+    {"window_size": (-1, 4, 16), "dilation": (1, 11, 5), "base_size": (-1, 44, 80)},  # layer 1
+    {"window_size": (-1, 4, 16), "dilation": (1, 11, 5), "base_size": (-1, 44, 80)},  # layer 2
+    {"window_size": (-1, 4, 16), "dilation": (1, 11, 5), "base_size": (-1, 44, 80)},  # layer 3
+    {"window_size": (-1, 4, 16), "dilation": (1, 11, 5), "base_size": (-1, 44, 80)},  # layer 4
+    {"window_size": (-1, 4, 16), "dilation": (1, 11, 5), "base_size": (-1, 44, 80)},  # layer 5
+    {"window_size": (-1, 4, 16), "dilation": (1, 11, 5), "base_size": (-1, 44, 80)},  # layer 6
+    {"window_size": (-1, 4, 16), "dilation": (1, 11, 5), "base_size": (-1, 44, 80)},  # layer 7
+    {"window_size": (-1, 4, 16), "dilation": (1, 11, 5), "base_size": (-1, 44, 80)},  # layer 8
+    {"window_size": (-1, 4, 16), "dilation": (1, 11, 5), "base_size": (-1, 44, 80)},  # layer 9
+    {"window_size": (-1, 4, 16), "dilation": (1, 11, 5), "base_size": (-1, 44, 80)},  # layer 10
+    {"window_size": (-1, 12, 16), "stride": (1, 4, 1), "dilation": (1, 1, 5), "base_size": (-1, 44, 80)},  # layer 11
+    {"window_size": (-1, 12, 16), "stride": (1, 4, 1), "dilation": (1, 1, 5), "base_size": (-1, 44, 80)},  # layer 12
+    {"window_size": (-1, 12, 24), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 13
+    {"window_size": (-1, 12, 24), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 14
+    {"window_size": (-1, 12, 24), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 15
+    {"window_size": (-1, 12, 24), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 16
+    {"window_size": (-1, 12, 24), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 17
+    {"window_size": (-1, 12, 24), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 18
+    {"window_size": (-1, 12, 24), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 19
+    {"window_size": (-1, 12, 24), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 20
+    {"window_size": (-1, 12, 24), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 21
+    {"window_size": (-1, 12, 24), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 22
+    {"window_size": (-1, 20, 40), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 23
+    {"window_size": (-1, 28, 56), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 24
+    {"window_size": (-1, 20, 40), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 25
+    {"window_size": (-1, 28, 56), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 26
+    None,  # layer 27
+    {"window_size": (-1, 28, 56), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 28
+    {"window_size": (-1, 20, 40), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 29
+    {"window_size": (-1, 20, 40), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 30
+    {"window_size": (-1, 28, 56), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 31
+    {"window_size": (-1, 28, 56), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 32
+    {"window_size": (-1, 20, 40), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 33
+    {"window_size": (-1, 28, 56), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 34
+    {"window_size": (-1, 20, 40), "stride": (1, 4, 8), "base_size": (-1, 44, 80)},  # layer 35
+]

--- a/cosmos_predict2/configs/base/config_video2world.py
+++ b/cosmos_predict2/configs/base/config_video2world.py
@@ -18,16 +18,12 @@ from enum import Enum
 
 import attrs
 
-from cosmos_predict2.conditioner import (
-    BooleanFlag,
-    ReMapkey,
-    TextAttr,
-    VideoConditioner,
+from cosmos_predict2.conditioner import BooleanFlag, ReMapkey, TextAttr, VideoConditioner
+from cosmos_predict2.configs.base.config_natten import (
+    PREDICT2_VIDEO2WORLD_NET_2B_NATTEN_PARAMETERS,
+    PREDICT2_VIDEO2WORLD_NET_14B_NATTEN_PARAMETERS,
 )
-from cosmos_predict2.configs.base.config_text2image import (
-    CosmosGuardrailConfig,
-    SolverTimestampConfig,
-)
+from cosmos_predict2.configs.base.config_text2image import CosmosGuardrailConfig, SolverTimestampConfig
 from cosmos_predict2.configs.base.defaults.ema import EMAConfig
 from cosmos_predict2.models.text2image_dit import SACConfig
 from cosmos_predict2.models.video2world_dit import MinimalV1LVGDiT
@@ -287,3 +283,146 @@ PREDICT2_VIDEO2WORLD_PIPELINE_14B_720P_10FPS = deepcopy(PREDICT2_VIDEO2WORLD_PIP
 PREDICT2_VIDEO2WORLD_PIPELINE_14B_720P_10FPS.state_t = 16
 # 14B, resolution 720p, fps 16
 PREDICT2_VIDEO2WORLD_PIPELINE_14B_720P_16FPS = PREDICT2_VIDEO2WORLD_PIPELINE_14B
+
+
+# Predict2 + NATTEN
+
+# Cosmos Predict2 Video2World + NATTEN 2B
+PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_2B = deepcopy(PREDICT2_VIDEO2WORLD_NET_2B)
+PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_2B.natten_parameters = PREDICT2_VIDEO2WORLD_NET_2B_NATTEN_PARAMETERS
+
+PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_2B = Video2WorldPipelineConfig(
+    adjust_video_noise=True,
+    conditioner=L(VideoConditioner)(
+        fps=L(ReMapkey)(
+            dropout_rate=0.0,
+            dtype=None,
+            input_key="fps",
+            output_key="fps",
+        ),
+        padding_mask=L(ReMapkey)(
+            dropout_rate=0.0,
+            dtype=None,
+            input_key="padding_mask",
+            output_key="padding_mask",
+        ),
+        text=L(TextAttr)(
+            dropout_rate=0.2,
+            input_key=["t5_text_embeddings"],
+        ),
+        use_video_condition=L(BooleanFlag)(
+            dropout_rate=0.0,
+            input_key="fps",
+            output_key="use_video_condition",
+        ),
+    ),
+    conditioning_strategy=str(ConditioningStrategy.FRAME_REPLACE),
+    min_num_conditional_frames=1,
+    max_num_conditional_frames=2,
+    net=PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_2B,
+    precision="bfloat16",
+    rectified_flow_t_scaling_factor=1.0,
+    resize_online=True,
+    resolution="720",
+    ema=L(EMAConfig)(enabled=False),  # defaults to inference
+    sigma_conditional=0.0001,
+    sigma_data=1.0,
+    state_ch=16,
+    state_t=24,
+    text_encoder_class="T5",
+    tokenizer=L(TokenizerInterface)(
+        chunk_duration=81,
+        temporal_window=16,
+        load_mean_std=False,
+        name="tokenizer",
+        vae_pth="checkpoints/nvidia/Cosmos-Predict2-2B-Video2World/tokenizer/tokenizer.pth",
+    ),
+    prompt_refiner_config=CosmosReason1Config(
+        checkpoint_dir="checkpoints/nvidia/Cosmos-Reason1-7B",
+        offload_model_to_cpu=True,
+        enabled=True,
+    ),
+    guardrail_config=CosmosGuardrailConfig(
+        checkpoint_dir="checkpoints/",
+        offload_model_to_cpu=True,
+        enabled=True,
+    ),
+)
+
+# Cosmos Predict2 Video2World + NATTEN 14B
+PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_14B = deepcopy(PREDICT2_VIDEO2WORLD_NET_14B)
+PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_14B.natten_parameters = PREDICT2_VIDEO2WORLD_NET_14B_NATTEN_PARAMETERS
+
+PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_14B = Video2WorldPipelineConfig(
+    adjust_video_noise=True,
+    conditioner=L(VideoConditioner)(
+        fps=L(ReMapkey)(
+            dropout_rate=0.0,
+            dtype=None,
+            input_key="fps",
+            output_key="fps",
+        ),
+        padding_mask=L(ReMapkey)(
+            dropout_rate=0.0,
+            dtype=None,
+            input_key="padding_mask",
+            output_key="padding_mask",
+        ),
+        text=L(TextAttr)(
+            dropout_rate=0.2,
+            input_key=["t5_text_embeddings"],
+        ),
+        use_video_condition=L(BooleanFlag)(
+            dropout_rate=0.0,
+            input_key="fps",
+            output_key="use_video_condition",
+        ),
+    ),
+    conditioning_strategy=str(ConditioningStrategy.FRAME_REPLACE),
+    min_num_conditional_frames=1,
+    max_num_conditional_frames=2,
+    net=PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_14B,
+    precision="bfloat16",
+    rectified_flow_t_scaling_factor=1.0,
+    resize_online=True,
+    resolution="720",
+    ema=L(EMAConfig)(enabled=False),  # defaults to inference
+    sigma_conditional=0.0001,
+    sigma_data=1.0,
+    state_ch=16,
+    state_t=24,
+    text_encoder_class="T5",
+    tokenizer=L(TokenizerInterface)(
+        chunk_duration=81,
+        temporal_window=16,
+        load_mean_std=False,
+        name="tokenizer",
+        vae_pth="checkpoints/nvidia/Cosmos-Predict2-14B-Video2World/tokenizer/tokenizer.pth",
+    ),
+    prompt_refiner_config=CosmosReason1Config(
+        checkpoint_dir="checkpoints/nvidia/Cosmos-Reason1-7B",
+        offload_model_to_cpu=True,
+        enabled=True,
+    ),
+    guardrail_config=CosmosGuardrailConfig(
+        checkpoint_dir="checkpoints/",
+        offload_model_to_cpu=True,
+        enabled=True,
+    ),
+)
+
+
+# Cosmos Predict2 Video2World + NATTEN pipeline config variants
+# 2B, 720p, 10 fps
+PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_2B_720P_10FPS = deepcopy(PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_2B)
+PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_2B_720P_10FPS.state_t = 16
+
+# 2B, 720p, 16 fps
+PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_2B_720P_16FPS = PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_2B
+
+# 14B, 720p, 10 fps
+PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_14B_720P_10FPS = deepcopy(PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_14B)
+PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_14B_720P_10FPS.state_t = 16
+
+# 14B, 720p, 16 fps
+PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_14B_720P_16FPS = PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_14B

--- a/cosmos_predict2/module/neighborhood_attn.py
+++ b/cosmos_predict2/module/neighborhood_attn.py
@@ -13,13 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections.abc import Mapping, Sized
+from collections.abc import Mapping, Sequence
 from typing import Optional
 
 import torch
 from torch import nn
-
-# from imaginaire.utils import log
 
 try:
     import natten
@@ -34,7 +32,20 @@ except ImportError:
     HAS_NATTEN = False
 
     def neighborhood_attention_generic(*args, **kwargs):
-        raise RuntimeError("You attempted to run neighborhood attention, but you don't have NATTEN installed.")
+        raise RuntimeError(
+            "You attempted to run Cosmos-Predict2 + NATTEN, but NATTEN is not installed. "
+            "Refer to natten.org/install for install instructions, or use "
+            "the cosmos-predict2 container image."
+        )
+
+
+from cosmos_predict2.module.attention import get_device_cc
+
+# Only allowing on Hopper and Blackwell for now, since Hopper FNA and
+# Blackwell FNA can deliver excellent speedup over SOL baselines.
+# Other architectures will be enabled as soon as good kernels for them
+# land in NATTEN.
+ALLOWED_COMPUTE_CAPS = [90, 100]
 
 
 from collections import namedtuple
@@ -43,61 +54,112 @@ VideoSize = namedtuple("VideoSize", ["T", "H", "W"])
 
 
 class NeighborhoodAttention(nn.Module):
-    def __init__(self, gna_parameters, base_attn_op):
+    def __init__(self, natten_parameters, base_attn_op):
         super(NeighborhoodAttention, self).__init__()
 
         self.base_attn_op = base_attn_op
 
-        self.gna_parameters = gna_parameters
-        if (
-            not isinstance(gna_parameters, Mapping)
-            or "window_size" not in gna_parameters
-            or "stride" not in gna_parameters
+        self.natten_parameters = natten_parameters
+        if not isinstance(natten_parameters, Mapping) or "window_size" not in natten_parameters:
+            raise ValueError(
+                f"Expected `natten_parameters` to be a dict with at least keys `window_size`, got {natten_parameters=}."
+            )
+
+        self.window_size = natten_parameters["window_size"]
+        self.stride = 1 if "stride" not in natten_parameters else natten_parameters["stride"]
+        self.dilation = 1 if "dilation" not in natten_parameters else natten_parameters["dilation"]
+        self.is_causal = False if "is_causal" not in natten_parameters else natten_parameters["is_causal"]
+
+        if not isinstance(self.window_size, Sequence) or len(self.window_size) != 3:
+            raise ValueError("Invalid window_size value. Expected an iterable of length 3, got " f"{self.window_size}.")
+
+        if (not isinstance(self.stride, Sequence) or len(self.stride) != 3) and not isinstance(self.stride, int):
+            raise ValueError(
+                "Invalid stride value. Expected an iterable of length 3, or integer, got " f"{self.stride}."
+            )
+
+        if (not isinstance(self.dilation, Sequence) or len(self.dilation) != 3) and not isinstance(self.dilation, int):
+            raise ValueError(
+                "Invalid dilation value. Expected an iterable of length 3, or integer, got " f"{self.dilation}."
+            )
+
+        if (not isinstance(self.is_causal, Sequence) or len(self.is_causal) != 3) and not isinstance(
+            self.is_causal, bool
         ):
             raise ValueError(
-                "Expected `gna_parameters` to be a dict with keys window_size " f"and stride, got {gna_parameters=}."
+                "Invalid is_causal value. Expected an iterable of length 3, or boolean, got " f"{self.is_causal}."
             )
 
-        self.natten_window_size = gna_parameters["window_size"]
-        self.natten_stride = gna_parameters["stride"]
-        self.natten_base_size = None if "base_size" not in gna_parameters else gna_parameters["base_size"]
-
-        if not isinstance(self.natten_window_size, Sized) or len(self.natten_window_size) != 3:
+        self.base_size = None if "base_size" not in natten_parameters else natten_parameters["base_size"]
+        if self.base_size is not None and (not isinstance(self.base_size, Sequence) or len(self.base_size) != 3):
             raise ValueError(
-                "Invalid window_size value. Expected an iterable of length 3, got " f"{self.natten_window_size}."
+                "Invalid base feature map size. Expected an iterable of length 3, or None, got " f"{self.base_size}."
             )
 
-        if (not isinstance(self.natten_stride, Sized) or len(self.natten_stride) != 3) and not isinstance(
-            self.natten_stride, int
-        ):
-            raise ValueError(
-                "Invalid stride value. Expected an iterable of length 3, or integer, got " f"{self.natten_stride}."
+        # Configurations
+        # Tuned for 720p and window sizes (24, 12, 24), (16, 12, 24), and stride (1, 4, 8).
+        self.default_config = {
+            "backend": "flex-fna",
+            "q_tile_shape": (4, 4, 4),
+            "kv_tile_shape": (4, 4, 4),
+            "torch_compile": False,
+        }
+        self.default_config_cuda = {
+            "backend": "cutlass-fna",
+            "q_tile_shape": (4, 4, 4),
+            "kv_tile_shape": (4, 4, 8),
+            "backward_q_tile_shape": (4, 4, 8),
+            "backward_kv_tile_shape": (4, 4, 8),
+            "backward_use_pt_reduction": False,
+        }
+        self.inference_configs = {
+            # Hopper (SM90)
+            90: {
+                "backend": "hopper-fna",
+                "q_tile_shape": (4, 4, 8),
+                "kv_tile_shape": (4, 4, 8),
+            },
+            # Blackwell (SM100)
+            100: {
+                "backend": "blackwell-fna",
+                "q_tile_shape": (8, 4, 8),
+                "kv_tile_shape": (4, 4, 8),
+                "run_persistent_kernel": True,
+            },
+        }
+
+    def get_adaptive_parameters(self, window_size, stride, dilation, is_causal, input_shape, base_size=None):
+        window_size = tuple(w if w > 1 else x for x, w in zip(input_shape, window_size))
+        stride = tuple(stride for _ in range(3)) if isinstance(stride, int) else tuple(x for x in stride)
+        dilation = tuple(dilation for _ in range(3)) if isinstance(dilation, int) else tuple(x for x in dilation)
+        is_causal = tuple(is_causal for _ in range(3)) if isinstance(is_causal, bool) else tuple(x for x in is_causal)
+
+        # Scale window size and stride according to some base input size
+        # For example, if window size is (8, 8, 8), stride is (1, 2, 2), for a base
+        # input/feature map size of (16, 16, 16); then if the input feat map in this iteration
+        # has shape (8, 8, 8), we should use window size (4, 4, 4), and stride (1, 1, 1).
+        if base_size is not None:
+            base_shape = tuple(b if b > 0 else x for x, b in zip(input_shape, base_size))
+
+            scale = tuple(x / b for x, b in zip(input_shape, base_shape))
+
+            scaled_window_size = tuple(min(max(2, round(w * s)), x) for w, s, x in zip(window_size, scale, input_shape))
+            scaled_stride = tuple(min(max(1, round(st * s)), w) for w, s, st in zip(scaled_window_size, scale, stride))
+
+            max_dilation = tuple(x // w for x, w in zip(input_shape, scaled_window_size))
+            scaled_dilation = tuple(
+                min(max(1, round(d * s)), max_d) for d, s, max_d in zip(dilation, scale, max_dilation)
             )
 
-        if self.natten_base_size is not None and (
-            not isinstance(self.natten_base_size, Sized) or len(self.natten_base_size) != 3
-        ):
-            raise ValueError(
-                "Invalid base feature map size. Expected an iterable of length 3, or None, got "
-                f"{self.natten_base_size}."
-            )
+            window_size = scaled_window_size
+            stride = scaled_stride
+            dilation = scaled_dilation
 
-        # Flex can be faster with multi-dim tiling, but it's buggy...
-        self.backend = "fna"  # Choices (as of natten v0.20.0.dev0): fna, fna-blackwell, flex
+        assert all(x >= w * d for x, w, d in zip(input_shape, window_size, dilation))
+        assert all(w >= s for w, s in zip(window_size, stride))
+        assert all(isinstance(c, bool) for c in is_causal)
 
-        # Kernel configurations
-
-        self.q_tile_shape = None
-        self.kv_tile_shape = None
-        # self.q_tile_shape = (4, 4, 4)
-        # self.kv_tile_shape = (4, 4, 4)
-
-        self.backward_q_tile_shape = None  # fna only
-        self.backward_kv_tile_shape = None  # fna only
-        self.backward_kv_splits = None  # fna only
-        self.backward_use_pt_reduction = False  # fna only
-
-        self.run_persistent_kernel = True  # blackwell-fna only
+        return window_size, stride, dilation, is_causal
 
     def forward(
         self,
@@ -112,6 +174,33 @@ class NeighborhoodAttention(nn.Module):
                 f"{q_B_L_H_D.shape=}, {k_B_L_H_D.shape=}, {v_B_L_H_D.shape=}."
             )
 
+        device = q_B_L_H_D.device
+        compute_cap = get_device_cc(device)
+        requires_grad = q_B_L_H_D.requires_grad or k_B_L_H_D.requires_grad or v_B_L_H_D.requires_grad
+        is_cuda = torch.cuda.is_available() and torch.version.cuda and device.type == "cuda"
+
+        if compute_cap not in ALLOWED_COMPUTE_CAPS:
+            allowed_devices = ", ".join([f"SM{x}" for x in ALLOWED_COMPUTE_CAPS])
+            raise NotImplementedError(
+                "Cosmos-Predict2 + NATTEN is only allowed for Hopper and "
+                f"certain Blackwell GPUs ({allowed_devices}), but your GPU "
+                f"is SM{compute_cap}."
+            )
+
+        if requires_grad:
+            raise NotImplementedError(
+                "Cosmos-Predict2 + NATTEN does not support training yet, " f"got {requires_grad=}."
+            )
+
+        if not is_cuda:
+            raise NotImplementedError("Cosmos-Predict2 + NATTEN requires CUDA, tensors were on " f"{device=}.")
+
+        natten_configuration = self.default_config
+        if requires_grad and is_cuda:
+            natten_configuration = self.default_config_cuda
+        elif is_cuda and compute_cap in self.inference_configs.keys():
+            natten_configuration = self.inference_configs[compute_cap]
+
         batch, seqlen, heads, head_dim = q_B_L_H_D.shape
         T, H, W = video_size
 
@@ -119,66 +208,28 @@ class NeighborhoodAttention(nn.Module):
             raise ValueError("Mismatch between seqlen and video_size dimensions; got " f"{video_size=}, {seqlen=}.")
 
         if T > 1:
-            # assert T in [20, 24]
-
             input_shape = (T, H, W)
 
-            # 720p
-            # window_size = (T, 12, 24)
-            # stride = (1, 4, 8)
-
-            # 480p
-            # window_size = (T, 12, 16)
-            # stride = (1, 4, 16)
-
-            window_size = tuple(w if w > 1 else x for x, w in zip(input_shape, self.natten_window_size))
-            stride = (
-                tuple(self.natten_stride for _ in range(3))
-                if isinstance(self.natten_stride, int)
-                else tuple(x for x in self.natten_stride)
+            window_size, stride, dilation, is_causal = self.get_adaptive_parameters(
+                window_size=self.window_size,
+                stride=self.stride,
+                dilation=self.dilation,
+                is_causal=self.is_causal,
+                input_shape=input_shape,
+                base_size=self.base_size,
             )
 
-            # Scale window size and stride according to some base input size
-            # For example, if window size is (8, 8, 8), stride is (1, 2, 2), for a base
-            # input/feature map size of (16, 16, 16); then if the input feat map in this iteration
-            # has shape (8, 8, 8), we should use window size (4, 4, 4), and stride (1, 1, 1).
-            if self.natten_base_size is not None:
-                base_shape = tuple(b if b > 0 else x for x, b in zip(input_shape, self.natten_base_size))
-
-                scale = tuple(x / b for x, b in zip(input_shape, base_shape))
-
-                scaled_window_size = tuple(
-                    min(max(2, round(w * s)), x) for w, s, x in zip(window_size, scale, input_shape)
-                )
-                scaled_stride = tuple(
-                    min(max(1, round(st * s)), w) for w, s, st in zip(scaled_window_size, scale, stride)
-                )
-
-                window_size = scaled_window_size
-                stride = scaled_stride
-
-            assert all(x >= w for x, w in zip(input_shape, window_size))
-            assert all(w >= s for w, s in zip(window_size, stride))
-
         elif T == 1:
-            # Do self attention for image model
+            # Do self attention for image model; skip natten
             return self.base_attn_op(q_B_L_H_D, k_B_L_H_D, v_B_L_H_D)
 
         else:
             raise ValueError(f"Invalid dimension {T=}.")
 
-        dilation = 1  # = (1, 1, 1)
-        causal = False  # = (False, False, False)
-
         q = q_B_L_H_D.view(batch, *input_shape, heads, head_dim)
         k = k_B_L_H_D.view(batch, *input_shape, heads, head_dim)
         v = v_B_L_H_D.view(batch, *input_shape, heads, head_dim)
 
-        # log.debug(
-        #     f"Running neighborhood attention on qkv.shape={q.shape} ({input_shape=}), "
-        #     f"{window_size=}, {stride=}, {dilation=}, {causal=}, "
-        #     f"q_tile_shape={self.q_tile_shape}, kv_tile_shape={self.kv_tile_shape}, backend={self.backend}."
-        # )
         out = neighborhood_attention_generic(
             query=q,
             key=k,
@@ -186,15 +237,8 @@ class NeighborhoodAttention(nn.Module):
             kernel_size=window_size,
             stride=stride,
             dilation=dilation,
-            is_causal=causal,
-            backend=self.backend,
-            q_tile_shape=self.q_tile_shape,
-            kv_tile_shape=self.kv_tile_shape,
-            backward_q_tile_shape=self.backward_q_tile_shape,
-            backward_kv_tile_shape=self.backward_kv_tile_shape,
-            backward_kv_splits=self.backward_kv_splits,
-            backward_use_pt_reduction=self.backward_use_pt_reduction,
-            run_persistent_kernel=self.run_persistent_kernel,
+            is_causal=is_causal,
+            **natten_configuration,
         )
 
         return out.view(batch, seqlen, heads, head_dim)

--- a/documentations/inference_text2world.md
+++ b/documentations/inference_text2world.md
@@ -146,6 +146,9 @@ Generation parameters:
 
 Performance optimization parameters:
 - `--use_cuda_graphs`: Use CUDA Graphs to accelerate DiT inference.
+- `--natten`: Use sparse attention variants built with [NATTEN](https://natten.org). This feature is
+    only available with 720p resolution, and on Hopper and specific Blackwell datacenter cards
+    (B200 and GB200) for now. [Learn more](performance.md).
 - `--benchmark`: Run in benchmark mode to measure average generation time.
 
 Text2Image phase parameters:

--- a/documentations/inference_video2world.md
+++ b/documentations/inference_video2world.md
@@ -318,6 +318,9 @@ Generation parameters:
 
 Performance parameters:
 - `--use_cuda_graphs`: Use CUDA Graphs to accelerate DiT inference.
+- `--natten`: Use sparse attention variants built with [NATTEN](https://natten.org). This feature is
+    only available with 720p resolution, and on Hopper and specific Blackwell datacenter cards
+    (B200 and GB200) for now. [Learn more](performance.md).
 - `--benchmark`: Run in benchmark mode to measure average generation time.
 
 Multi-GPU inference:

--- a/documentations/inference_video2world.md
+++ b/documentations/inference_video2world.md
@@ -287,6 +287,24 @@ Example output is included at `assets/video2world_lvg/example_output.mp4`.
 
 If using the 14B model, it is recommended to offload the prompt refiner model or guardrail models to CPU to save GPU memory (see [Using the 14B Model](#using-the-14b-model) for reference).
 
+### Faster inference with Sparse Attention
+If you're targeting 720p generation, and you're using a Hopper (compute capability 9.0) or
+Blackwell datacenter-class (compute capability 10.0) GPU, you can optionally run
+[Video2World + NATTEN](performance.md#sparse-attention-powered-by-natten) by using the `--natten`
+flag.
+
+```bash
+python -m examples.video2world \
+    --model_size 2B \
+    --input_path $INPUT_PATH \
+    --prompt "${PROMPT}" \
+    --natten \
+    --save_path output/video2world_2b_with_natten.mp4
+```
+
+Running with NATTEN can bring you anywhere from 1.7X to 2.6X end-to-end speedup over the base model,
+depending on variant, frame rate, and hardware.
+
 ## API Documentation
 
 The `video2world.py` script supports the following command-line arguments:

--- a/documentations/inference_video2world.md
+++ b/documentations/inference_video2world.md
@@ -303,7 +303,8 @@ python -m examples.video2world \
 ```
 
 Running with NATTEN can bring you anywhere from 1.7X to 2.6X end-to-end speedup over the base model,
-depending on variant, frame rate, and hardware.
+depending on variant, frame rate, and hardware. In terms of quality, we've observed that in many
+domains the sparse attention variants are comparable with the base models.
 
 ## API Documentation
 

--- a/documentations/performance.md
+++ b/documentations/performance.md
@@ -42,6 +42,43 @@ Note: (OOM) indicates "Out of Memory" - the model is too large to run on that GP
 
 Note: Video2World was run with 480p resolution and at 16 FPS.
 
+### Sparse Attention powered by [NATTEN](https://natten.org)
+Video2World offers variants trained with sparse attention, which can accelerate inference up to 2.5X
+on the Hopper and Blackwell architectures.
+This feature is only available for 720p inference, and only on NVIDIA GPUs with compute capability
+9.0 or 10.0.
+
+Since many concurrent works in sparse attention for video generation report performance numbers with
+Flash Attention V2, We note that the baseline models run with the state of the art attention kernels
+for those architectures, namely [Flash Attention V3](https://arxiv.org/abs/2407.08608) for Hopper,
+and cuDNN Attention for Blackwell.
+
+NATTEN's [Hopper](https://natten.org/backends/#hopper-fna-fmha) and
+[Blackwell FNA](https://natten.org/backends/#blackwell-fna-fmha) kernels can deliver speedups
+**proportional to reduction in FLOPs** over FAv3 and cuDNN's Blackwell FMHA.
+
+The following table shows generation times (720p, 16fps) with and without sparsity across supported NVIDIA GPUs:
+
+| GPU Hardware     | 2B-Video2World | 2B-Video2World + [NATTEN](https://natten.org) | 14B-Video2World | 14B-Video2World + [NATTEN](https://natten.org) |
+|------------------|----------------|------------------|----------------|------------------|
+| NVIDIA B200      | 123.9 sec      | 54.0 sec (2.3X)  | 439.4 sec      | 223.1 sec (2.0X) |
+| NVIDIA H200 SXM  | 221.7 sec      | 89.4 sec (2.5X)  | 836.9 sec      | 412.9 sec (2.0X) |
+| NVIDIA H200 NVL  | 267.2 sec      | 104.3 sec (2.6X) | 1006.7 sec     | 489.5 sec (2.1X) |
+| NVIDIA H100 PCIe | 378.5 sec      | 149.6 sec (2.5X) | 1425.4 sec     | 706.9 sec (2.0X) |
+| NVIDIA H100 NVL  | 355.7 sec      | 138.7 sec (2.6X) | 1348.6 sec     | 677.0 sec (2.0X) |
+| NVIDIA H100 SXM  | 228.8 sec      | 94.2 sec (2.4X)  | 856.9 sec      | 426.0 sec (2.0X) |
+
+The following table shows generation times (720p, 10fps) with and without sparsity across supported NVIDIA GPUs:
+
+| GPU Hardware     | 2B-Video2World | 2B-Video2World + [NATTEN](https://natten.org) | 14B-Video2World | 14B-Video2World + [NATTEN](https://natten.org) |
+|------------------|----------------|------------------|----------------|------------------|
+| NVIDIA B200      | 62.4 sec       | 32.6 sec (1.9X)  | 230.0 sec      | 136.5 sec (1.7X) |
+| NVIDIA H200 SXM  | 111.1 sec      | 52.9 sec (2.1X)  | 436.7 sec      | 252.1 sec (1.7X) |
+| NVIDIA H200 NVL  | 133.1 sec      | 60.7 sec (2.2X)  | 519.3 sec      | 296.6 sec (1.8X) |
+| NVIDIA H100 PCIe | 187.9 sec      | 87.4 sec (2.1X)  | 749.2 sec      | 439.3 sec (1.7X) |
+| NVIDIA H100 NVL  | 175.5 sec      | 79.0 sec (2.2X)  | 711.5 sec      | 418.0 sec (1.7X) |
+| NVIDIA H100 SXM  | 115.1 sec      | 56.0 sec (2.0X)  | 447.9 sec      | 260.0 sec (1.7X) |
+
 ### Post-training performance
 
 Review the [AgiBot-Fisheye](post-training_video2world_agibot_fisheye.md) post-training example, which contains performance numbers on different GPUs.

--- a/documentations/performance.md
+++ b/documentations/performance.md
@@ -49,9 +49,9 @@ This feature is only available for 720p inference, and only on NVIDIA GPUs with 
 9.0 or 10.0.
 
 Since many concurrent works in sparse attention for video generation report performance numbers with
-Flash Attention V2, We note that the baseline models run with the state of the art attention kernels
-for those architectures, namely [Flash Attention V3](https://arxiv.org/abs/2407.08608) for Hopper,
-and cuDNN Attention for Blackwell.
+Flash Attention V2 as baseline, we note that our baseline models run with SOTA attention kernels
+for the Hopper ([Flash Attention V3](https://arxiv.org/abs/2407.08608)) and Blackwell (cuDNN
+Attention) architectures.
 
 NATTEN's [Hopper](https://natten.org/backends/#hopper-fna-fmha) and
 [Blackwell FNA](https://natten.org/backends/#blackwell-fna-fmha) kernels can deliver speedups

--- a/documentations/performance.md
+++ b/documentations/performance.md
@@ -44,7 +44,7 @@ Note: Video2World was run with 480p resolution and at 16 FPS.
 
 ### Sparse Attention powered by [NATTEN](https://natten.org)
 Video2World offers variants trained with sparse attention, which can accelerate inference up to 2.5X
-on the Hopper and Blackwell architectures.
+on the Hopper and Blackwell architectures with comparable quality.
 This feature is only available for 720p inference, and only on NVIDIA GPUs with compute capability
 9.0 or 10.0.
 

--- a/documentations/performance.md
+++ b/documentations/performance.md
@@ -102,3 +102,8 @@ It is recommended to use the 14B models for
 The 14B models generally produce higher fidelity results with better coherence and detail, but come with increased computational costs. The 2B models offer a good balance of quality and performance for many practical applications while being more resource-efficient.
 
 For most development and testing scenarios, starting with the 2B models is recommended. You can then scale up to 14B models when higher quality is needed and hardware resources permit.
+
+If you have a Hopper (compute capability 9.0) or Blackwell datacenter-class
+(compute capability 10.0) GPU, you can also experiment with the Sparse Attention variants. Sparse
+variants are comparable in terms of visual quality with their base counterparts across various
+domains.

--- a/documentations/setup.md
+++ b/documentations/setup.md
@@ -121,6 +121,13 @@ python -m scripts.download_checkpoints --model_types video2world --model_sizes 2
 You can pass `--checkpoint_dir <path to ckpt>` if you want to control where to put the checkpoints.
 You can also add `--verify_md5` flag to verify MD5 checksums of downloaded files. If checksums don't match, models will be automatically redownloaded.
 
+To download models with [sparse attention](performance.md#sparse-attention-powered-by-natten), run the
+script with the `--natten` option:
+
+```bash
+python -m scripts.download_checkpoints --model_types video2world --model_sizes 2B 14B --resolution 720 --fps 10 16 --natten
+```
+
 ## Troubleshooting
 
 ### CUDA/GPU Issues

--- a/examples/text2world.py
+++ b/examples/text2world.py
@@ -118,6 +118,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--offload_prompt_refiner", action="store_true", help="Offload prompt refiner to CPU to save GPU memory"
     )
+    parser.add_argument(
+        "--natten",
+        action="store_true",
+        help="Run the sparse attention variant (with NATTEN).",
+    )
     return parser.parse_args()
 
 

--- a/examples/video2world.py
+++ b/examples/video2world.py
@@ -176,7 +176,7 @@ def parse_args() -> argparse.Namespace:
 
 def setup_pipeline(args: argparse.Namespace, text_encoder=None):
     log.info(f"Using model size: {args.model_size}")
-    if args.natten:
+    if hasattr(args, "natten") and args.natten:
         assert args.model_size in ["2B", "14B"]
         config = (
             PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_2B

--- a/examples/video2world.py
+++ b/examples/video2world.py
@@ -28,6 +28,8 @@ from megatron.core import parallel_state
 from cosmos_predict2.configs.base.config_video2world import (
     PREDICT2_VIDEO2WORLD_PIPELINE_2B,
     PREDICT2_VIDEO2WORLD_PIPELINE_14B,
+    PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_2B,
+    PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_14B,
 )
 from cosmos_predict2.pipelines.video2world import (
     _IMAGE_EXTENSIONS,
@@ -164,12 +166,38 @@ def parse_args() -> argparse.Namespace:
         help="Run the generation in benchmark mode. It means that generation will be rerun a few times and the average generation time will be shown.",
     )
     parser.add_argument("--use_cuda_graphs", action="store_true", help="Use CUDA Graphs for the text2image inference.")
+    parser.add_argument(
+        "--natten",
+        action="store_true",
+        help="Run Video2World + NATTEN (sparse attention variant).",
+    )
     return parser.parse_args()
 
 
 def setup_pipeline(args: argparse.Namespace, text_encoder=None):
     log.info(f"Using model size: {args.model_size}")
-    if args.model_size == "2B":
+    if args.natten:
+        assert args.model_size in ["2B", "14B"]
+        config = (
+            PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_2B
+            if args.model_size == "2B"
+            else PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_14B
+        )
+
+        config.resolution = args.resolution
+
+        if args.fps == 10:
+            config.state_t = 16
+
+        if args.resolution != "720":
+            raise NotImplementedError("Cosmos-Predict2 + NATTEN only supports 720p inference at the moment.")
+
+        if args.aspect_ratio != "16:9":
+            raise NotImplementedError("Cosmos-Predict2 + NATTEN only supports 16:9 aspect ratio at the moment.")
+
+        dit_path = f"checkpoints/nvidia/Cosmos-Predict2-{args.model_size}-Video2World/model-720p-{args.fps}fps-natten.pt"
+
+    elif args.model_size == "2B":
         config = PREDICT2_VIDEO2WORLD_PIPELINE_2B
 
         config.resolution = args.resolution

--- a/scripts/download_checkpoints.py
+++ b/scripts/download_checkpoints.py
@@ -69,6 +69,9 @@ def parse_args():
     parser.add_argument(
         "--verify_md5", action="store_true", default=False, help="Verify MD5 checksums of existing files."
     )
+    parser.add_argument(
+        "--natten", action="store_true", default=False, help="Download Video2World + NATTEN (sparse attention) checkpoints."
+    )
     args = parser.parse_args()
     return args
 
@@ -90,6 +93,11 @@ MD5_CHECKSUM_LOOKUP = {
     "nvidia/Cosmos-Predict2-14B-Text2Image/tokenizer/tokenizer.pth": "854fcb755005951fa5b329799af6199f",
     "nvidia/Cosmos-Predict2-2B-Video2World/tokenizer/tokenizer.pth": "854fcb755005951fa5b329799af6199f",
     "nvidia/Cosmos-Predict2-14B-Video2World/tokenizer/tokenizer.pth": "854fcb755005951fa5b329799af6199f",
+    # Video2World Sparse Variants
+    "nvidia/Cosmos-Predict2-2B-Video2World/model-720p-16fps-natten.pt": "91355cc9979f47aeb7ee991193e88305",
+    "nvidia/Cosmos-Predict2-2B-Video2World/model-720p-10fps-natten.pt": "4ef2b03da1ca0888e3a4054dc8b4b2f0",
+    "nvidia/Cosmos-Predict2-14B-Video2World/model-720p-16fps-natten.pt": "09167672edf4bcd456318d8498cb6f36",
+    "nvidia/Cosmos-Predict2-14B-Video2World/model-720p-10fps-natten.pt": "86d5e27ac75021798ab594f257600e50",
     # Cosmos-Reason1-7B
     "nvidia/Cosmos-Reason1-7B/model-00001-of-00004.safetensors": "90198d3b3dab5a00b7b9288cecffa5e9",
     "nvidia/Cosmos-Reason1-7B/model-00002-of-00004.safetensors": "6bde197d212f2a83ae19585b87de500e",
@@ -188,6 +196,15 @@ def main(args):
                     download_model(
                         args.checkpoint_dir, repo_id, verify_md5=args.verify_md5, allow_patterns=allow_patterns
                     )
+                    # Sparse variant (if any)
+                    if args.natten and res == "720":
+                        download_model(
+                            args.checkpoint_dir,
+                            repo_id,
+                            verify_md5=args.verify_md5,
+                            allow_patterns=f"model-{res}p-{fps}fps-natten.pt"
+                        )
+
             # donwload the remaining
             repo_id = f"nvidia/{model_size_mapping[size]}-{model_type_mapping['video2world']}"
             download_model(args.checkpoint_dir, repo_id, verify_md5=args.verify_md5, allow_patterns="tokenizer/*")


### PR DESCRIPTION
Introduces sparsity into the Cosmos Predict2 Diffusion Transformer architecture, by replacing self attention operations with various forms of [Neighborhood Attention (NA)](https://arxiv.org/abs/2204.07143), including and especially the most recent [Generalized NA (GNA)](https://arxiv.org/abs/2504.16922), as well as other useful NA patterns such as [Dilated NA](https://arxiv.org/abs/2209.15001).

The selection process was a simple profiling over various NA parameters with layer granularity. Those parameters include some simply local (strided) sliding window attention, and some sparse-global dilated sliding window attention. All patterns in the pool were derived using [NATTENSim](https://arxiv.org/abs/2504.16922) and confirmed to be highly or fully block-sparse.

These variants can bring 1.7X to 2.6X speedup to 720p Video2World inference depending on frame-rate, model size, and GPU architecture. The baselines are [Flash Attention 3](https://arxiv.org/abs/2407.08608) and cuDNN Attention, which are the state of the art for the Hopper and Blackwell architectures respectively. NATTEN's [Hopper](https://natten.org/backends/#hopper-fna-fmha) and [Blackwell FNA](https://natten.org/backends/#blackwell-fna-fmha) kernels are built on top of [CUTLASS](https://github.com/NVIDIA/cutlass/)'s FMHA kernels, which achieve similar performance to the baselines.

For more information refer to [Generalized Neighborhood Attention](https://arxiv.org/abs/2504.16922), and the [NATTEN project](https://natten.org).

Expected speedups with 720p, 16FPS:

| GPU      | 2B   | 14B  |
|----------|------|------|
| B200     | 2.3X | 2.0X |
| H100 SXM | 2.4X | 2.0X |
| H200 SXM | 2.5X | 2.0X |

Expected speedups with 720p, 10FPS:

| GPU      | 2B   | 14B  |
|----------|------|------|
| B200     | 1.9X | 1.7X |
| H100 SXM | 2.0X | 1.7X |
| H200 SXM | 2.1X | 1.7X |

Speedups on other Hopper and Blackwell datacenter GPUs are reported in the docs as well.