### PR TITLE
[feat add on] Efficient Fine-Tuning of video2world models via LoRA adapters

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[flake8]
+enable-extensions = G
+select = B,C,E,F,G,P,SIM1,T4,W,B9
+max-line-length = 120
+# C408 ignored because we like the dict keyword argument syntax
+# E501 is not flexible enough, we're using B950 instead
+ignore =
+    E203,E305,E402,E501,E721,E741,F405,F821,F841,F999,W503,W504,C408,E302,W291,E303,E226,E265
+exclude =
+    third_party

--- a/cosmos_predict2/callbacks/iter_speed.py
+++ b/cosmos_predict2/callbacks/iter_speed.py
@@ -23,7 +23,6 @@ from imaginaire.model import ImaginaireModel
 from imaginaire.trainer import ImaginaireTrainer
 from imaginaire.utils import log
 from imaginaire.utils.distributed import rank0_only
-from imaginaire.utils.easy_io import easy_io
 
 
 class IterSpeed(EveryN):

--- a/cosmos_predict2/configs/action_conditioned/config.py
+++ b/cosmos_predict2/configs/action_conditioned/config.py
@@ -13,23 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import attrs
-
 from cosmos_predict2.conditioner import ActionConditioner, BooleanFlag, ReMapkey, TextAttr
 from cosmos_predict2.configs.base.config_video2world import (
     ConditioningStrategy,
     CosmosGuardrailConfig,
     CosmosReason1Config,
-    SolverTimestampConfig,
     Video2WorldPipelineConfig,
 )
 from cosmos_predict2.configs.base.defaults.ema import EMAConfig
 from cosmos_predict2.models.text2image_dit import SACConfig
 from cosmos_predict2.models.video2world_action_dit import ActionConditionedMinimalV1LVGDiT
 from cosmos_predict2.tokenizers.tokenizer import TokenizerInterface
-from imaginaire.config import make_freezable
 from imaginaire.lazy_config import LazyCall as L
-from imaginaire.lazy_config import LazyDict
 
 # Cosmos Predict2 Video2World 2B
 PREDICT2_VIDEO2WORLD_NET_2B_ACTION_CONDITIONED = L(ActionConditionedMinimalV1LVGDiT)(

--- a/cosmos_predict2/configs/action_conditioned/defaults/model.py
+++ b/cosmos_predict2/configs/action_conditioned/defaults/model.py
@@ -15,9 +15,7 @@
 
 from hydra.core.config_store import ConfigStore
 
-from cosmos_predict2.configs.action_conditioned.config import (
-    PREDICT2_VIDEO2WORLD_PIPELINE_2B_ACTION_CONDITIONED,
-)
+from cosmos_predict2.configs.action_conditioned.config import PREDICT2_VIDEO2WORLD_PIPELINE_2B_ACTION_CONDITIONED
 from cosmos_predict2.models.video2world_action_model import Predict2Video2WorldActionConditionedModel
 from cosmos_predict2.models.video2world_model import Predict2ModelManagerConfig, Predict2Video2WorldModelConfig
 from imaginaire.lazy_config import LazyCall as L

--- a/cosmos_predict2/configs/base/config.py
+++ b/cosmos_predict2/configs/base/config.py
@@ -17,8 +17,12 @@ from typing import Any, List
 
 import attrs
 
-from cosmos_predict2.configs.action_conditioned.defaults.data import register_training_and_val_data_action_conditioned
-from cosmos_predict2.configs.action_conditioned.defaults.model import register_model_action_conditioned
+from cosmos_predict2.configs.action_conditioned.defaults.data import (
+    register_training_and_val_data_action_conditioned,
+)
+from cosmos_predict2.configs.action_conditioned.defaults.model import (
+    register_model_action_conditioned,
+)
 from cosmos_predict2.configs.base.defaults.callbacks import register_callbacks
 from cosmos_predict2.configs.base.defaults.checkpoint import register_checkpoint
 from cosmos_predict2.configs.base.defaults.data import register_training_and_val_data
@@ -71,7 +75,7 @@ def make_config() -> Config:
     c.trainer.type = Trainer
     c.trainer.max_iter = 400_000
     c.trainer.logging_iter = 10
-    c.trainer.validation_iter = 100
+    c.trainer.validation_iter = 500
     c.trainer.run_validation = False
     c.trainer.callbacks = None
 

--- a/cosmos_predict2/configs/base/defaults/model.py
+++ b/cosmos_predict2/configs/base/defaults/model.py
@@ -31,10 +31,7 @@ from cosmos_predict2.configs.base.config_video2world import (
     PREDICT2_VIDEO2WORLD_PIPELINE_14B_720P_10FPS,
     PREDICT2_VIDEO2WORLD_PIPELINE_14B_720P_16FPS,
 )
-from cosmos_predict2.models.text2image_model import (
-    Predict2Text2ImageModel,
-    Predict2Text2ImageModelConfig,
-)
+from cosmos_predict2.models.text2image_model import Predict2Text2ImageModel, Predict2Text2ImageModelConfig
 from cosmos_predict2.models.video2world_model import (
     Predict2ModelManagerConfig,
     Predict2Video2WorldModel,

--- a/cosmos_predict2/configs/base/experiment/cosmos_nemo_assets_lora.py
+++ b/cosmos_predict2/configs/base/experiment/cosmos_nemo_assets_lora.py
@@ -1,0 +1,181 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from hydra.core.config_store import ConfigStore
+from megatron.core import parallel_state
+from torch.utils.data import DataLoader, DistributedSampler
+
+from cosmos_predict2.data.dataset_video import Dataset
+from imaginaire.lazy_config import LazyCall as L
+
+
+def get_sampler(dataset) -> DistributedSampler:
+    return DistributedSampler(
+        dataset,
+        num_replicas=parallel_state.get_data_parallel_world_size(),
+        rank=parallel_state.get_data_parallel_rank(),
+        shuffle=True,
+        seed=0,
+    )
+
+
+cs = ConfigStore.instance()
+
+
+# Cosmos-NeMo-Assets LoRA video2world example (use same dataloader as working config)
+example_video_dataset_cosmos_nemo_assets = L(Dataset)(
+    dataset_dir="datasets/cosmos_nemo_assets",
+    num_frames=93,
+    video_size=(704, 1280),
+)
+
+dataloader_train_cosmos_nemo_assets = L(DataLoader)(
+    dataset=example_video_dataset_cosmos_nemo_assets,
+    sampler=L(get_sampler)(dataset=example_video_dataset_cosmos_nemo_assets),
+    batch_size=1,  # Use same batch size as working config
+    drop_last=True,
+    num_workers=8,
+    pin_memory=True,
+)
+
+# torchrun --nproc_per_node=8 --master_port=12341 -m scripts.train --config=cosmos_predict2/configs/base/config.py -- experiment=predict2_video2world_lora_training_2b_cosmos_nemo_assets model.config.train_architecture=lora
+predict2_video2world_lora_training_2b_cosmos_nemo_assets = dict(
+    defaults=[
+        {"override /model": "predict2_video2world_fsdp_2b"},
+        {"override /optimizer": "fusedadamw"},
+        {"override /scheduler": "lambdalinear"},
+        {"override /ckpt_type": "standard"},
+        {"override /dataloader_val": "mock"},
+        "_self_",
+    ],
+    job=dict(
+        project="posttraining",
+        group="video2world_lora",
+        name="2b_cosmos_nemo_assets",
+    ),
+    model=dict(
+        config=dict(
+            # Enable LoRA training
+            train_architecture="lora",
+            # LoRA configuration parameters for video2world
+            lora_rank=16,
+            lora_alpha=16,
+            lora_target_modules="q_proj,k_proj,v_proj,output_proj,mlp.layer1,mlp.layer2",
+            init_lora_weights=True,
+            pipe_config=dict(
+                ema=dict(enabled=True),
+                prompt_refiner_config=dict(enabled=False),
+                guardrail_config=dict(enabled=False),
+            ),
+        )
+    ),
+    model_parallel=dict(
+        context_parallel_size=2,
+    ),
+    dataloader_train=dataloader_train_cosmos_nemo_assets,
+    trainer=dict(
+        distributed_parallelism="fsdp",
+        callbacks=dict(
+            iter_speed=dict(hit_thres=10),
+        ),
+        max_iter=1000,
+    ),
+    checkpoint=dict(
+        save_iter=200,
+    ),
+    optimizer=dict(
+        lr=2 ** (-14.5),
+    ),
+    scheduler=dict(
+        warm_up_steps=[0],
+        cycle_lengths=[1_000],
+        f_max=[0.6],
+        f_min=[0.0],
+    ),
+)
+
+# torchrun --nproc_per_node=8 --nnodes=4 --rdzv_id 123 --rdzv_backend c10d --rdzv_endpoint $MASTER_ADDR:1234 -m scripts.train --config=cosmos_predict2/configs/base/config.py -- experiment=predict2_video2world_lora_training_14b_cosmos_nemo_assets model.config.train_architecture=lora
+predict2_video2world_lora_training_14b_cosmos_nemo_assets = dict(
+    defaults=[
+        {"override /model": "predict2_video2world_fsdp_14b"},
+        {"override /optimizer": "fusedadamw"},
+        {"override /scheduler": "lambdalinear"},
+        {"override /ckpt_type": "standard"},
+        {"override /dataloader_val": "mock"},
+        "_self_",
+    ],
+    job=dict(
+        project="posttraining",
+        group="video2world_lora",
+        name="14b_cosmos_nemo_assets",
+    ),
+    model=dict(
+        config=dict(
+            # Enable LoRA training
+            train_architecture="lora",
+            # LoRA configuration parameters for video2world 14B
+            lora_rank=32,  # Higher rank for larger model
+            lora_alpha=32,
+            lora_target_modules="q_proj,k_proj,v_proj,output_proj,mlp.layer1,mlp.layer2",
+            init_lora_weights=True,
+            pipe_config=dict(
+                ema=dict(enabled=True),
+                prompt_refiner_config=dict(enabled=False),
+                guardrail_config=dict(enabled=False),
+            ),
+        )
+    ),
+    model_parallel=dict(
+        context_parallel_size=8,
+    ),
+    dataloader_train=dataloader_train_cosmos_nemo_assets,
+    trainer=dict(
+        distributed_parallelism="fsdp",
+        callbacks=dict(
+            iter_speed=dict(hit_thres=10),
+        ),
+        max_iter=1000,  # Use same as working config
+    ),
+    checkpoint=dict(
+        save_iter=200,  # Use same as working config
+    ),
+    optimizer=dict(
+        lr=2 ** (-14.5),  # Use same as working config
+        weight_decay=0.2,
+    ),
+    scheduler=dict(
+        warm_up_steps=[0],
+        cycle_lengths=[1_000],
+        f_max=[0.25],
+        f_min=[0.0],
+    ),
+)
+
+
+for _item in [
+    # 2b, cosmos_nemo_assets video2world LoRA
+    predict2_video2world_lora_training_2b_cosmos_nemo_assets,
+    # 14b, cosmos_nemo_assets video2world LoRA
+    predict2_video2world_lora_training_14b_cosmos_nemo_assets,
+]:
+    # Get the experiment name from the global variable.
+    experiment_name = [name.lower() for name, value in globals().items() if value is _item][0]
+
+    cs.store(
+        group="experiment",
+        package="_global_",
+        name=experiment_name,
+        node=_item,
+    )

--- a/cosmos_predict2/configs/conditioner.py
+++ b/cosmos_predict2/configs/conditioner.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
-
 from hydra.core.config_store import ConfigStore
 
 from cosmos_predict2.conditioner import BooleanFlag, ReMapkey, TextAttr, VideoConditioner

--- a/cosmos_predict2/data/action_conditioned/dataset_utils.py
+++ b/cosmos_predict2/data/action_conditioned/dataset_utils.py
@@ -19,7 +19,6 @@ https://github.com/bytedance/IRASim/blob/main/dataset/dataset_util.py
 """
 
 import math
-import os
 
 import numpy as np
 import torch

--- a/cosmos_predict2/data/dataset_image.py
+++ b/cosmos_predict2/data/dataset_image.py
@@ -24,12 +24,7 @@ import torch
 from torch.utils.data import Dataset
 from torchvision import transforms as T
 
-from cosmos_predict2.data.dataset_utils import (
-    _NUM_T5_TOKENS,
-    _T5_EMBED_DIM,
-    Resize_Preprocess,
-    ToTensorImage,
-)
+from cosmos_predict2.data.dataset_utils import _NUM_T5_TOKENS, _T5_EMBED_DIM, Resize_Preprocess, ToTensorImage
 from imaginaire.utils import log
 
 """

--- a/cosmos_predict2/data/dataset_video.py
+++ b/cosmos_predict2/data/dataset_video.py
@@ -25,12 +25,7 @@ from torch.utils.data import Dataset
 from torchvision import transforms as T
 from torchvision.transforms.v2 import UniformTemporalSubsample
 
-from cosmos_predict2.data.dataset_utils import (
-    _NUM_T5_TOKENS,
-    _T5_EMBED_DIM,
-    Resize_Preprocess,
-    ToTensorVideo,
-)
+from cosmos_predict2.data.dataset_utils import _NUM_T5_TOKENS, _T5_EMBED_DIM, Resize_Preprocess, ToTensorVideo
 from imaginaire.utils import log
 
 """

--- a/cosmos_predict2/models/text2image_model.py
+++ b/cosmos_predict2/models/text2image_model.py
@@ -25,10 +25,7 @@ from torch.distributed.tensor import DTensor
 from torch.nn.modules.module import _IncompatibleKeys
 
 from cosmos_predict2.conditioner import TextCondition
-from cosmos_predict2.configs.base.config_text2image import (
-    PREDICT2_TEXT2IMAGE_PIPELINE_2B,
-    Text2ImagePipelineConfig,
-)
+from cosmos_predict2.configs.base.config_text2image import PREDICT2_TEXT2IMAGE_PIPELINE_2B, Text2ImagePipelineConfig
 from cosmos_predict2.networks.model_weights_stats import WeightTrainingStat
 from cosmos_predict2.pipelines.text2image import Text2ImagePipeline
 from cosmos_predict2.utils.checkpointer import non_strict_load_model
@@ -362,6 +359,10 @@ class Predict2Text2ImageModel(ImaginaireModel):
             raise ValueError(f"Invalid loss_reduce: {self.loss_reduce}")
 
         return output_batch, kendall_loss
+
+    @torch.no_grad()
+    def validation_step(self, data_batch: dict, data_batch_idx: int) -> tuple[dict, torch.Tensor]:
+        return self.training_step(data_batch, data_batch_idx)
 
     # ------------------ Checkpointing ------------------
 

--- a/cosmos_predict2/models/video2world_model.py
+++ b/cosmos_predict2/models/video2world_model.py
@@ -26,10 +26,7 @@ from torch.distributed.tensor import DTensor
 from torch.nn.modules.module import _IncompatibleKeys
 
 from cosmos_predict2.conditioner import DataType, TextCondition
-from cosmos_predict2.configs.base.config_video2world import (
-    PREDICT2_VIDEO2WORLD_PIPELINE_2B,
-    Video2WorldPipelineConfig,
-)
+from cosmos_predict2.configs.base.config_video2world import PREDICT2_VIDEO2WORLD_PIPELINE_2B, Video2WorldPipelineConfig
 from cosmos_predict2.networks.model_weights_stats import WeightTrainingStat
 from cosmos_predict2.pipelines.video2world import Video2WorldPipeline
 from cosmos_predict2.utils.checkpointer import non_strict_load_model
@@ -57,6 +54,25 @@ class Predict2Video2WorldModelConfig:
     init_lora_weights: bool = True
 
     precision: str = "bfloat16"
+
+    def __attrs_post_init__(self):
+        """Validate LoRA configuration after initialization."""
+        if self.train_architecture == "lora":
+            if self.lora_rank <= 0:
+                raise ValueError(f"LoRA rank must be positive, got {self.lora_rank}")
+            if self.lora_alpha <= 0:
+                raise ValueError(f"LoRA alpha must be positive, got {self.lora_alpha}")
+            if not self.lora_target_modules.strip():
+                raise ValueError("LoRA target_modules cannot be empty")
+
+            # Warn about potentially inefficient configurations
+            if self.lora_rank > 64:
+                log.warning(f"High LoRA rank ({self.lora_rank}) may reduce training efficiency")
+            if self.lora_alpha != self.lora_rank:
+                log.info(
+                    f"LoRA alpha ({self.lora_alpha}) != rank ({self.lora_rank}), scaling factor: {self.lora_alpha/self.lora_rank}"
+                )
+
     input_video_key: str = "video"
     input_image_key: str = "images"
     loss_reduce: str = "mean"
@@ -131,6 +147,8 @@ class Predict2Video2WorldModel(ImaginaireModel):
                     lora_target_modules=config.lora_target_modules,
                     init_lora_weights=config.init_lora_weights,
                 )
+            # Enhanced LoRA logging
+            self._log_lora_statistics()
         else:
             self.pipe.denoising_model().requires_grad_(True)
         total_params = sum(p.numel() for p in self.parameters())
@@ -213,28 +231,112 @@ class Predict2Video2WorldModel(ImaginaireModel):
 
     def add_lora_to_model(
         self,
-        model,
-        lora_rank=4,
-        lora_alpha=4,
-        lora_target_modules="q_proj,k_proj,v_proj,output_proj,mlp.layer1,mlp.layer2",
-        init_lora_weights=True,
-    ):
-        from peft import LoraConfig, inject_adapter_in_model
+        model: torch.nn.Module,
+        lora_rank: int = 4,
+        lora_alpha: int = 4,
+        lora_target_modules: str = "q_proj,k_proj,v_proj,output_proj,mlp.layer1,mlp.layer2",
+        init_lora_weights: bool = True,
+    ) -> None:
+        """Add LoRA (Low-Rank Adaptation) adapters to the model.
 
-        # Add LoRA to UNet
+        This function injects LoRA adapters into specified modules of the model,
+        enabling parameter-efficient fine-tuning by training only a small number
+        of additional parameters.
+
+        Args:
+            model: The PyTorch model to add LoRA adapters to
+            lora_rank: The rank of the LoRA adaptation matrices. Higher rank allows
+                      more expressiveness but uses more parameters (default: 4)
+            lora_alpha: Scaling parameter for LoRA. Controls the magnitude of the
+                       LoRA adaptation (default: 4)
+            lora_target_modules: Comma-separated string of module names to target
+                               for LoRA adaptation (default: attention and MLP layers)
+            init_lora_weights: Whether to initialize LoRA weights properly (default: True)
+
+        Raises:
+            ImportError: If PEFT library is not installed
+            ValueError: If invalid parameters are provided
+            RuntimeError: If LoRA injection fails
+        """
+        try:
+            from peft import LoraConfig, inject_adapter_in_model
+        except ImportError as e:
+            raise ImportError(
+                "PEFT library is required for LoRA training. Please install it with: pip install peft"
+            ) from e
+
+        # Validate parameters
+        if lora_rank <= 0:
+            raise ValueError(f"LoRA rank must be positive, got {lora_rank}")
+        if lora_alpha <= 0:
+            raise ValueError(f"LoRA alpha must be positive, got {lora_alpha}")
+
+        target_modules_list = [module.strip() for module in lora_target_modules.split(",")]
+        if not target_modules_list:
+            raise ValueError("LoRA target_modules cannot be empty")
+
+        # Validate target modules exist in model
+        model_module_names = set(name for name, _ in model.named_modules())
+        invalid_modules = []
+        for target_module in target_modules_list:
+            # Check if any module contains this target pattern
+            if not any(target_module in module_name for module_name in model_module_names):
+                invalid_modules.append(target_module)
+
+        if invalid_modules:
+            log.warning(f"Target modules not found in model: {invalid_modules}")
+
+        # Add LoRA to model
         self.lora_alpha = lora_alpha
+
+        log.info(f"Adding LoRA adapters: rank={lora_rank}, alpha={lora_alpha}, targets={target_modules_list}")
 
         lora_config = LoraConfig(
             r=lora_rank,
             lora_alpha=lora_alpha,
             init_lora_weights=init_lora_weights,
-            target_modules=lora_target_modules.split(","),
+            target_modules=target_modules_list,
         )
-        model = inject_adapter_in_model(lora_config, model)
-        for param in model.parameters():
-            # Upcast LoRA parameters into fp32
+
+        try:
+            model = inject_adapter_in_model(lora_config, model)
+        except Exception as e:
+            raise RuntimeError(f"Failed to inject LoRA adapters into model: {e}") from e
+
+        # Count and log LoRA parameters
+        lora_params = 0
+        total_params = 0
+        for name, param in model.named_parameters():
+            total_params += param.numel()
             if param.requires_grad:
+                lora_params += param.numel()
+                # Upcast LoRA parameters into fp32
                 param.data = param.to(torch.float32)
+
+        log.info(
+            f"LoRA injection successful: {lora_params:,} trainable parameters out of {total_params:,} total ({100*lora_params/total_params:.3f}%)"
+        )
+
+    def _log_lora_statistics(self) -> None:
+        """Log detailed LoRA parameter statistics."""
+        lora_params_by_type = {}
+        total_lora_params = 0
+
+        for name, param in self.pipe.dit.named_parameters():
+            if param.requires_grad and "lora" in name.lower():
+                param_type = "lora_A" if "lora_A" in name else "lora_B" if "lora_B" in name else "other_lora"
+                if param_type not in lora_params_by_type:
+                    lora_params_by_type[param_type] = 0
+                lora_params_by_type[param_type] += param.numel()
+                total_lora_params += param.numel()
+
+        if total_lora_params > 0:
+            log.info("LoRA parameter breakdown:")
+            for param_type, count in lora_params_by_type.items():
+                log.info(f"  {param_type}: {count:,} parameters")
+            log.info(f"  Total LoRA: {total_lora_params:,} parameters")
+        else:
+            log.warning("No LoRA parameters found in model")
 
     def setup_data_key(self) -> None:
         self.input_video_key = self.config.input_video_key  # by default it is video key for Video diffusion model
@@ -384,6 +486,10 @@ class Predict2Video2WorldModel(ImaginaireModel):
             raise ValueError(f"Invalid loss_reduce: {self.loss_reduce}")
 
         return output_batch, kendall_loss
+
+    @torch.no_grad()
+    def validation_step(self, data_batch: dict, data_batch_idx: int) -> tuple[dict, torch.Tensor]:
+        return self.training_step(data_batch, data_batch_idx)
 
     # ------------------ Checkpointing ------------------
 

--- a/cosmos_predict2/pipelines/text2image.py
+++ b/cosmos_predict2/pipelines/text2image.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from contextlib import contextmanager
 from typing import Any, List, Tuple, Union
 
 import numpy as np
@@ -20,7 +21,7 @@ import torch
 from einops import rearrange
 from megatron.core import parallel_state
 from torch.distributed.device_mesh import DeviceMesh
-from torch.distributed.fsdp import fully_shard
+from torch.distributed.fsdp import FSDPModule, fully_shard
 from tqdm import tqdm
 
 from cosmos_predict2.auxiliary.text_encoder import CosmosT5TextEncoder
@@ -31,14 +32,9 @@ from cosmos_predict2.models.utils import init_weights_on_device, load_state_dict
 from cosmos_predict2.module.denoise_prediction import DenoisePrediction
 from cosmos_predict2.module.denoiser_scaling import RectifiedFlowScaling
 from cosmos_predict2.pipelines.base import BasePipeline
-from cosmos_predict2.schedulers.rectified_flow_scheduler import (
-    RectifiedFlowAB2Scheduler,
-)
+from cosmos_predict2.schedulers.rectified_flow_scheduler import RectifiedFlowAB2Scheduler
 from cosmos_predict2.tokenizers.tokenizer import TokenizerInterface
-from cosmos_predict2.utils.dtensor_helper import (
-    DTensorFastEmaModelUpdater,
-    broadcast_dtensor_model_states,
-)
+from cosmos_predict2.utils.dtensor_helper import DTensorFastEmaModelUpdater, broadcast_dtensor_model_states
 from imaginaire.lazy_config import LazyDict, instantiate
 from imaginaire.utils import log, misc
 from imaginaire.utils.ema import FastEmaModelUpdater
@@ -93,6 +89,7 @@ class Text2ImagePipeline(BasePipeline):
         text_encoder_path: str = "",
         device: str = "cuda",
         torch_dtype: torch.dtype = torch.bfloat16,
+        load_ema_to_reg: bool = False,
     ) -> Any:
         # Create a pipe
         pipe = Text2ImagePipeline(device=device, torch_dtype=torch_dtype)
@@ -159,11 +156,12 @@ class Text2ImagePipeline(BasePipeline):
 
         if dit_path:
             state_dict = load_state_dict(dit_path)
+            prefix_to_load = "net_ema." if load_ema_to_reg else "net."
             # drop net. prefix
             state_dict_dit_compatible = dict()
             for k, v in state_dict.items():
-                if k.startswith("net."):
-                    state_dict_dit_compatible[k[4:]] = v
+                if k.startswith(prefix_to_load):
+                    state_dict_dit_compatible[k[len(prefix_to_load) :]] = v
                 else:
                     state_dict_dit_compatible[k] = v
             pipe.dit.load_state_dict(state_dict_dit_compatible, strict=False, assign=True)
@@ -440,3 +438,25 @@ class Text2ImagePipeline(BasePipeline):
 
         log.success("Image generation completed successfully")
         return image
+
+    @contextmanager
+    def ema_scope(self, context: Any = None, is_cpu: bool = False):
+        if self.config.ema.enabled:
+            # https://github.com/pytorch/pytorch/issues/144289
+            for module in self.dit.modules():
+                if isinstance(module, FSDPModule):
+                    module.reshard()
+            self.dit_ema_worker.cache(self.dit.parameters(), is_cpu=is_cpu)
+            self.dit_ema_worker.copy_to(src_model=self.dit_ema, tgt_model=self.dit)
+            if context is not None:
+                log.info(f"{context}: Switched to EMA weights")
+        try:
+            yield None
+        finally:
+            if self.config.ema.enabled:
+                for module in self.dit.modules():
+                    if isinstance(module, FSDPModule):
+                        module.reshard()
+                self.dit_ema_worker.restore(self.dit.parameters())
+                if context is not None:
+                    log.info(f"{context}: Restored training weights")

--- a/cosmos_predict2/pipelines/video2world_action.py
+++ b/cosmos_predict2/pipelines/video2world_action.py
@@ -25,9 +25,7 @@ from cosmos_predict2.configs.base.config_video2world import Video2WorldPipelineC
 from cosmos_predict2.models.utils import load_state_dict
 from cosmos_predict2.module.denoiser_scaling import RectifiedFlowScaling
 from cosmos_predict2.pipelines.video2world import Video2WorldPipeline
-from cosmos_predict2.schedulers.rectified_flow_scheduler import (
-    RectifiedFlowAB2Scheduler,
-)
+from cosmos_predict2.schedulers.rectified_flow_scheduler import RectifiedFlowAB2Scheduler
 from cosmos_predict2.utils.context_parallel import cat_outputs_cp, split_inputs_cp
 from imaginaire.lazy_config import instantiate
 from imaginaire.utils import log, misc

--- a/cosmos_predict2/tokenizers/interface.py
+++ b/cosmos_predict2/tokenizers/interface.py
@@ -13,9 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from abc import ABC, abstractmethod
-from typing import Optional
 
 import torch
 

--- a/cosmos_predict2/utils/misc.py
+++ b/cosmos_predict2/utils/misc.py
@@ -13,20 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 # import pathlib
-from functools import lru_cache
-from typing import Any, Optional, Tuple
+from typing import Any
 
 import torch
-import torch.nn.functional as F
 
 # from filelock import FileLock
 from torch import nn
-
-from imaginaire.utils import distributed, log
-from imaginaire.utils.easy_io import easy_io
 
 
 def disabled_train(self: Any, mode: bool = True) -> Any:

--- a/documentations/inference_text2image.md
+++ b/documentations/inference_text2image.md
@@ -93,6 +93,8 @@ Input and output parameters:
 
 Model selection:
 - `--model_size`: Size of the model to use (choices: "2B", "14B", default: "2B")
+- `--dit_path`: Custom path to the DiT model checkpoint for post-trained models (default: uses standard checkpoint path based on model_size)
+- `--load_ema`: Whether to use EMA weights from the post-trained DIT model checkpoint for generation.
 
 Generation parameters:
 - `--seed`: Random seed for reproducible results (default: 0)

--- a/documentations/inference_text2world.md
+++ b/documentations/inference_text2world.md
@@ -131,6 +131,7 @@ The `text2world.py` script supports the following command-line arguments:
 
 Model selection:
 - `--model_size`: Size of the model to use (choices: "2B", "14B", default: "2B")
+- `--load_ema`: Whether to use EMA weights from the post-trained DIT model checkpoint for generation.
 
 Input parameters:
 - `--prompt`: Text prompt describing the video to generate (default: predefined example prompt)
@@ -152,11 +153,12 @@ Performance optimization parameters:
 - `--benchmark`: Run in benchmark mode to measure average generation time.
 
 Text2Image phase parameters:
-- `--resolution`: Resolution for text2image generation (choices: "480", "720", default: "720")
-- `--fps`: FPS for video2world generation (choices: 10, 16, default: 16)
+- `--dit_path_text2image`: Custom path to the DiT model checkpoint for post-trained Text2Image models
 
 Video2World phase parameters:
-- `--dit_path`: Custom path to the DiT model checkpoint for post-trained models
+- `--dit_path_video2world`: Custom path to the DiT model checkpoint for post-trained Video2World models
+- `--resolution`: Resolution for text2image generation (choices: "480", "720", default: "720")
+- `--fps`: FPS for video2world generation (choices: 10, 16, default: 16)
 
 Multi-GPU inference:
 - `--num_gpus`: Number of GPUs to use for context parallel inference (default: 1)

--- a/documentations/inference_video2world.md
+++ b/documentations/inference_video2world.md
@@ -314,6 +314,7 @@ The `video2world.py` script supports the following command-line arguments:
 Model selection:
 - `--model_size`: Size of the model to use (choices: "2B", "14B", default: "2B")
 - `--dit_path`: Custom path to the DiT model checkpoint for post-trained models (default: uses standard checkpoint path based on model_size)
+- `--load_ema`: Whether to use EMA weights from the post-trained DIT model checkpoint for generation.
 - `--fps`: FPS of the model to use for video-to-world generation (choices: 10, 16, default: 16)
 - `--resolution`: Resolution of the model to use for video-to-world generation (choices: 480, 720, default: 720)
 

--- a/documentations/post-training_text2image.md
+++ b/documentations/post-training_text2image.md
@@ -244,6 +244,16 @@ CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python examples/text2image.py \
   --save_path output/cosmos_nemo_assets/generated_image_from_post-training.mp4
 ```
 
+To load EMA weights from the post-trained checkpoint, add argument `--load_ema`.
+```bash
+CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python examples/text2image.py \
+  --model_size 2B \
+  --dit_path "checkpoints/posttraining/text2image/2b_custom_data/checkpoints/model/iter_000001000.pt" \
+  --load_ema \
+  --prompt "A descriptive prompt for physical AI." \
+  --save_path output/cosmos_nemo_assets/generated_image_from_post-training.mp4
+```
+
 See [documentations/inference_text2image.md](documentations/inference_text2image.md) for inference run details.
 
 ##### Cosmos-Predict2-14B-Text2Image

--- a/documentations/post-training_text2image_cosmos_nemo_assets.md
+++ b/documentations/post-training_text2image_cosmos_nemo_assets.md
@@ -160,7 +160,17 @@ CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python examples/text2image.py \
   --model_size 2B \
   --dit_path "checkpoints/posttraining/text2image/2b_cosmos_nemo_assets/checkpoints/model/iter_000001000.pt" \
   --prompt "An image of sks teal robot." \
-  --save_path output/cosmos_nemo_assets/generated_video_teal_robot.jpg
+  --save_path output/generated_image_2b_teal_robot.jpg
+```
+
+To load EMA weights from the post-trained checkpoint, add argument `--load_ema`.
+```bash
+CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python examples/text2image.py \
+  --model_size 2B \
+  --dit_path "checkpoints/posttraining/text2image/2b_cosmos_nemo_assets/checkpoints/model/iter_000001000.pt" \
+  --prompt "An image of sks teal robot." \
+  --load_ema \
+  --save_path output/generated_image_2b_teal_robot_ema.jpg
 ```
 
 See [documentations/inference_text2image.md](documentations/inference_text2image.md) for inference run details.

--- a/documentations/post-training_video2world.md
+++ b/documentations/post-training_video2world.md
@@ -252,6 +252,17 @@ CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python examples/video2world.py \
   --save_path output/cosmos_nemo_assets/generated_video_from_post-training.mp4
 ```
 
+To load EMA weights from the post-trained checkpoint, add argument `--load_ema`.
+```bash
+CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python examples/video2world.py \
+  --model_size 2B \
+  --dit_path "checkpoints/posttraining/video2world/2b_custom_data/checkpoints/model/iter_000001000.pt" \
+  --load_ema \
+  --prompt "A descriptive prompt for physical AI." \
+  --input_path "assets/video2world_cosmos_nemo_assets/output_Digit_Lift_movie.jpg" \
+  --save_path output/cosmos_nemo_assets/generated_video_from_post-training.mp4
+```
+
 See [documentations/inference_video2world.md](documentations/inference_video2world.md) for inference run details.
 
 ##### Cosmos-Predict2-14B-Video2World

--- a/documentations/post-training_video2world_agibot_fisheye.md
+++ b/documentations/post-training_video2world_agibot_fisheye.md
@@ -245,11 +245,23 @@ PROMPT="The video captures a humanoid robot positioned in front of a fruit stand
 
 CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python examples/video2world.py \
   --model_size 2B \
-  --dit_path "checkpoints/posttraining/video2world/predict2_video2world_training_2b_agibot_head_center_fisheye_color/checkpoints/model/iter_000001000.pt" \
+  --dit_path "checkpoints/posttraining/video2world/2b_agibot_head_center_fisheye_color/checkpoints/model/iter_000001000.pt" \
   --prompt "${PROMPT}" \
-  --input_path "datasets/agibot_head_center_fisheye_color/val/task_327_episode_685393_window_0_frame_0-149.mp4" \
-  --num_conditional_frmaes 1 \
-  --save_path output/agibot_head_center_fisheye_color/generated_video_2b.mp4
+  --input_path "datasets/agibot_head_center_fisheye_color/val/videos/task_327_episode_685393_window_0_frame_0-149.mp4" \
+  --num_conditional_frames 1 \
+  --save_path output/generated_video_2b_agibot_fisheye.mp4
+```
+
+To load EMA weights from the post-trained checkpoint, add argument `--load_ema`.
+```bash
+CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python examples/video2world.py \
+  --model_size 2B \
+  --dit_path "checkpoints/posttraining/video2world/2b_agibot_head_center_fisheye_color/checkpoints/model/iter_000001000.pt" \
+  --prompt "${PROMPT}" \
+  --input_path "datasets/agibot_head_center_fisheye_color/val/videos/task_327_episode_685393_window_0_frame_0-149.mp4" \
+  --num_conditional_frames 1 \
+  --load_ema \
+  --save_path output/generated_video_2b_agibot_fisheye_ema.mp4
 ```
 
 See [documentations/inference_video2world.md](documentations/inference_video2world.md) for inference run details.

--- a/documentations/post-training_video2world_lora.md
+++ b/documentations/post-training_video2world_lora.md
@@ -1,0 +1,746 @@
+# Predict2 Video2World LoRA Post-Training Guide
+
+This guide provides instructions on running LoRA (Low-Rank Adaptation) post-training with Cosmos-Predict2 Video2World models.
+
+## Table of Contents
+- [Prerequisites](#prerequisites)
+- [Overview](#overview)
+- [Post-training Guide](#post-training-guide)
+
+## Prerequisites
+
+Before running LoRA post-training:
+
+1. **Environment setup**: Follow the [Setup guide](setup.md) for installation instructions.
+2. **Model checkpoints**: Download required model weights following the [Downloading Checkpoints](setup.md#downloading-checkpoints) section in the Setup guide.
+3. **Hardware considerations**: Review the [Performance guide](performance.md) for GPU requirements and model selection recommendations.
+4. **PEFT library**: The LoRA training uses the PEFT (Parameter-Efficient Fine-Tuning) library which should be installed as part of the environment setup.
+
+## Overview
+
+Cosmos-Predict2 provides two models for generating videos from a combination of text and visual inputs: `Cosmos-Predict2-2B-Video2World` and `Cosmos-Predict2-14B-Video2World`. These models can transform a still image or video clip into a longer, animated sequence guided by the text description.
+
+LoRA (Low-Rank Adaptation) is a parameter-efficient fine-tuning technique that allows you to adapt large pre-trained models to specific domains or tasks by training only a small number of additional parameters. This approach offers several advantages:
+
+### Key Benefits of LoRA Post-Training
+
+- **Memory Efficiency**: Only trains a small subset of parameters (typically < 1% of total model parameters)
+- **Faster Training**: Significantly reduced training time compared to full fine-tuning
+- **Storage Efficiency**: LoRA checkpoints are much smaller than full model checkpoints
+- **Flexibility**: Can maintain multiple LoRA adapters for different domains
+- **Preserved Base Capabilities**: Retains the original model's capabilities while adding domain-specific improvements
+
+We support LoRA post-training with example datasets:
+- [post-training_video2world_cosmos_nemo_assets](/documentations/post-training_video2world_cosmos_nemo_assets.md)
+  - Basic examples with a small 4 videos dataset (can be adapted for LoRA)
+- [post-training_video2world_agibot_fisheye](/documentations/post-training_video2world_agibot_fisheye.md)
+  - Examples with fisheye-view dataset (can be adapted for LoRA)
+- [post-training_video2world_gr00t](/documentations/post-training_video2world_gr00t.md)
+  - Examples with GR00T-dreams datasets (can be adapted for LoRA)
+
+### Cosmos-NeMo-Assets LoRA Configurations
+
+We provide dedicated LoRA configurations for Cosmos-NeMo-Assets in `cosmos_predict2/configs/base/experiment/cosmos_nemo_assets_lora.py`:
+- `predict2_video2world_lora_training_2b_cosmos_nemo_assets` - 2B model LoRA training
+- `predict2_video2world_lora_training_14b_cosmos_nemo_assets` - 14B model LoRA training
+
+## Post-training Guide
+
+### 1. Preparing Data
+
+The LoRA post-training data preparation follows the same format as standard post-training.
+
+Dataset folder format:
+```
+datasets/custom_video2world_lora_dataset/
+├── metas/
+│   ├── *.txt
+├── videos/
+│   ├── *.mp4
+```
+
+`metas` folder contains `.txt` files containing prompts describing the video content.
+`videos` folder contains the corresponding `.mp4` video files.
+
+After preparing `metas` and `videos` folders, run the following command to pre-compute T5-XXL embeddings:
+```bash
+python -m scripts.get_t5_embeddings --dataset_path datasets/custom_video2world_lora_dataset/
+```
+
+This script will create `t5_xxl` folder under the dataset root where the T5-XXL embeddings are saved as `.pickle` files:
+```
+datasets/custom_video2world_lora_dataset/
+├── metas/
+│   ├── *.txt
+├── videos/
+│   ├── *.mp4
+├── t5_xxl/
+│   ├── *.pickle
+```
+
+### 2. Creating Configs for LoRA Training
+
+Define dataloader from the prepared dataset with LoRA-specific configurations.
+
+For example:
+```python
+# custom LoRA dataset example
+example_video_lora_dataset = L(Dataset)(
+    dataset_dir="datasets/custom_video2world_lora_dataset",
+    num_frames=93,
+    video_size=(704, 1280),  # 720 resolution, 16:9 aspect ratio
+)
+
+dataloader_video_train_lora = L(DataLoader)(
+    dataset=example_video_lora_dataset,
+    sampler=L(get_sampler)(dataset=example_video_lora_dataset),
+    batch_size=2,  # Can use larger batch size due to memory efficiency
+    drop_last=True,
+    num_workers=8,
+    pin_memory=True,
+)
+```
+
+With the `dataloader_video_train_lora`, create a config for a LoRA training job.
+Here's a LoRA post-training example for video2world 2B model:
+
+```python
+predict2_video2world_lora_training_2b_custom_data = dict(
+    defaults=[
+        {"override /model": "predict2_video2world_fsdp_2b"},
+        {"override /optimizer": "fusedadamw"},
+        {"override /scheduler": "lambdalinear"},
+        {"override /ckpt_type": "standard"},
+        {"override /dataloader_val": "mock"},
+        "_self_",
+    ],
+    job=dict(
+        project="posttraining",
+        group="video2world_lora",
+        name="2b_custom_data",
+    ),
+    model=dict(
+        config=dict(
+            # Enable LoRA training
+            train_architecture="lora",
+            # LoRA configuration parameters
+            lora_rank=16,
+            lora_alpha=16,
+            lora_target_modules="q_proj,k_proj,v_proj,output_proj,mlp.layer1,mlp.layer2",
+            init_lora_weights=True,
+            pipe_config=dict(
+                ema=dict(enabled=True),     # enable EMA during training
+                prompt_refiner_config=dict(enabled=False),  # disable prompt refiner during training
+                guardrail_config=dict(enabled=False),   # disable guardrail during training
+            ),
+        )
+    ),
+    model_parallel=dict(
+        context_parallel_size=2,            # context parallelism size
+    ),
+    dataloader_train=dataloader_video_train_lora,
+    trainer=dict(
+        distributed_parallelism="fsdp",
+        callbacks=dict(
+            iter_speed=dict(hit_thres=10),
+        ),
+        max_iter=2000,                      # LoRA typically needs more iterations but trains faster
+    ),
+    checkpoint=dict(
+        save_iter=500,                      # checkpoints will be saved every 500 iterations.
+    ),
+    optimizer=dict(
+        lr=2 ** (-10),                      # LoRA typically uses higher learning rates
+    ),
+    scheduler=dict(
+        warm_up_steps=[0],
+        cycle_lengths=[2_000],              # adjust considering max_iter
+        f_max=[0.6],
+        f_min=[0.0],
+    ),
+)
+```
+
+Here's a LoRA post-training example for video2world 14B model:
+
+```python
+predict2_video2world_lora_training_14b_custom_data = dict(
+    defaults=[
+        {"override /model": "predict2_video2world_fsdp_14b"},
+        {"override /optimizer": "fusedadamw"},
+        {"override /scheduler": "lambdalinear"},
+        {"override /ckpt_type": "standard"},
+        {"override /dataloader_val": "mock"},
+        "_self_",
+    ],
+    job=dict(
+        project="posttraining",
+        group="video2world_lora",
+        name="14b_custom_data",
+    ),
+    model=dict(
+        config=dict(
+            # Enable LoRA training
+            train_architecture="lora",
+            # LoRA configuration parameters
+            lora_rank=32,                    # Higher rank for larger model
+            lora_alpha=32,
+            lora_target_modules="q_proj,k_proj,v_proj,output_proj,mlp.layer1,mlp.layer2",
+            init_lora_weights=True,
+            pipe_config=dict(
+                ema=dict(enabled=True),     # enable EMA during training
+                prompt_refiner_config=dict(enabled=False),  # disable prompt refiner during training
+                guardrail_config=dict(enabled=False),   # disable guardrail during training
+            ),
+        )
+    ),
+    model_parallel=dict(
+        context_parallel_size=4,
+    ),
+    dataloader_train=dataloader_video_train_lora,
+    trainer=dict(
+        distributed_parallelism="fsdp",
+        callbacks=dict(
+            iter_speed=dict(hit_thres=10),
+        ),
+        max_iter=1500,
+    ),
+    checkpoint=dict(
+        save_iter=300,
+    ),
+    optimizer=dict(
+        lr=2 ** (-11),
+    ),
+    scheduler=dict(
+        warm_up_steps=[0],
+        cycle_lengths=[1_500],
+        f_max=[0.6],
+        f_min=[0.0],
+    ),
+)
+```
+
+The config should be registered to ConfigStore:
+```python
+for _item in [
+    # 2b, custom LoRA data
+    predict2_video2world_lora_training_2b_custom_data,
+    # 14b, custom LoRA data
+    predict2_video2world_lora_training_14b_custom_data,
+]:
+    # Get the experiment name from the global variable.
+    experiment_name = [name.lower() for name, value in globals().items() if value is _item][0]
+
+    cs.store(
+        group="experiment",
+        package="_global_",
+        name=experiment_name,
+        node=_item,
+    )
+```
+
+### 2.1. LoRA Configuration Parameters
+
+The key LoRA-specific parameters in the config are:
+
+| Parameter | Description | Default | Recommended Values |
+|-----------|-------------|---------|-------------------|
+| `train_architecture` | Set to "lora" to enable LoRA training | "full" | **"lora"** (required) |
+| `lora_rank` | Rank of LoRA adaptation matrices | 16 | 8-32 (2B), 16-64 (14B) |
+| `lora_alpha` | LoRA scaling parameter | 16 | Usually equals lora_rank |
+| `lora_target_modules` | Target modules for LoRA adaptation | "q_proj,k_proj,v_proj,output_proj,mlp.layer1,mlp.layer2" | Comma-separated module names |
+| `init_lora_weights` | Initialize LoRA weights properly | True | Keep as True |
+
+#### LoRA Parameter Guidelines
+
+**For 2B Model:**
+- **Conservative**: rank=8, alpha=8, lr=2^(-12)
+- **Balanced**: rank=16, alpha=16, lr=2^(-10)
+- **Aggressive**: rank=32, alpha=32, lr=2^(-9)
+
+**For 14B Model:**
+- **Conservative**: rank=16, alpha=16, lr=2^(-12)
+- **Balanced**: rank=32, alpha=32, lr=2^(-11)
+- **Aggressive**: rank=64, alpha=64, lr=2^(-10)
+
+### 2.2. Config System
+
+In the above config example, it starts by overriding from the registered configs:
+```python
+    {"override /model": "predict2_video2world_fsdp_2b"},
+    {"override /optimizer": "fusedadamw"},
+    {"override /scheduler": "lambdalinear"},
+    {"override /ckpt_type": "standard"},
+    {"override /dataloader_val": "mock"},
+```
+
+The configuration system is organized as follows:
+
+```
+cosmos_predict2/configs/base/
+├── config.py                   # Main configuration class definition
+├── defaults/                   # Default configuration groups
+│   ├── callbacks.py            # Training callbacks configurations
+│   ├── checkpoint.py           # Checkpoint saving/loading configurations
+│   ├── data.py                 # Dataset and dataloader configurations
+│   ├── ema.py                  # Exponential Moving Average configurations
+│   ├── model.py                # Model architecture configurations
+│   ├── optimizer.py            # Optimizer configurations
+│   └── scheduler.py            # Learning rate scheduler configurations
+└── experiment/                 # Experiment-specific configurations
+    ├── cosmos_nemo_assets.py   # Experiments with cosmos_nemo_assets
+    ├── agibot_head_center_fisheye_color.py  # Experiments with agibot_head_center_fisheye_color
+    ├── groot.py                # Experiments with groot
+    └── utils.py                # Utility functions for experiments
+```
+
+The system provides several pre-defined configuration groups that can be mixed and matched:
+
+#### Model Configurations (`defaults/model.py`)
+- `predict2_video2world_fsdp_2b`: 2B parameter Video2World model with FSDP
+- `predict2_video2world_fsdp_14b`: 14B parameter Video2World model with FSDP
+
+Both can be used with LoRA by setting `train_architecture="lora"` in the model config.
+
+#### Optimizer Configurations (`defaults/optimizer.py`)
+- `fusedadamw`: FusedAdamW optimizer with standard settings
+- Custom optimizer configurations for different training scenarios
+
+LoRA typically uses higher learning rates than full fine-tuning.
+
+#### Scheduler Configurations (`defaults/scheduler.py`)
+- `constant`: Constant learning rate
+- `lambdalinear`: Linearly warming-up learning rate
+- Various learning rate scheduling strategies
+
+#### Data Configurations (`defaults/data.py`)
+- Training and validation dataset configurations
+
+#### Checkpoint Configurations (`defaults/checkpoint.py`)
+- `standard`: Standard local checkpoint handling
+
+#### Callback Configurations (`defaults/callbacks.py`)
+- `basic`: Essential training callbacks
+- Performance monitoring and logging callbacks
+
+In addition to the overridden values, the rest of the config setup overwrites or adds the other config details.
+
+### 3. Run a LoRA Training Job
+
+Run the following command to execute a LoRA post-training job with the custom data:
+
+#### For 2B Model:
+```bash
+EXP=predict2_video2world_lora_training_2b_custom_data
+torchrun --nproc_per_node=8 --master_port=12341 -m scripts.train \
+    --config=cosmos_predict2/configs/base/config.py \
+    -- experiment=${EXP} \
+    model.config.train_architecture=lora
+```
+
+#### For 14B Model:
+```bash
+EXP=predict2_video2world_lora_training_14b_custom_data
+torchrun --nproc_per_node=8 --master_port=12341 -m scripts.train \
+    --config=cosmos_predict2/configs/base/config.py \
+    -- experiment=${EXP} \
+    model.config.train_architecture=lora
+```
+
+The `model.config.train_architecture=lora` parameter explicitly enables LoRA training mode.
+
+#### Training Progress Monitoring
+
+During LoRA training, you'll see parameter statistics like:
+```
+Total parameters: 3.96B,
+Frozen parameters: 3,912,826,880,
+Trainable parameters: 45,875,200
+```
+
+This confirms that only a small fraction of parameters are being trained.
+
+The LoRA checkpoints will be saved to `checkpoints/PROJECT/GROUP/NAME`.
+In the above example, `PROJECT` is `posttraining`, `GROUP` is `video2world_lora`, `NAME` is `2b_custom_data`.
+
+```
+checkpoints/posttraining/video2world_lora/2b_custom_data/checkpoints/
+├── model/
+│   ├── iter_{NUMBER}.pt  # Contains base model + LoRA parameters
+├── optim/
+├── scheduler/
+├── trainer/
+├── latest_checkpoint.txt
+```
+
+### 4. Run Inference on LoRA Post-trained Checkpoints
+
+LoRA post-trained checkpoints require special handling during inference. Use the dedicated `video2world_lora.py` script:
+
+#### Cosmos-Predict2-2B-Video2World with LoRA
+
+For example, if a LoRA post-trained checkpoint with 1000 iterations is to be used, run the following command:
+
+```bash
+export NUM_GPUS=8
+export PYTHONPATH=$(pwd)
+
+torchrun --nproc_per_node=${NUM_GPUS} examples/video2world_lora.py \
+    --model_size 2B \
+    --dit_path "checkpoints/posttraining/video2world_lora/2b_custom_data/checkpoints/model/iter_000001000.pt" \
+    --input_path "assets/video2world/input0.jpg" \
+    --prompt "A descriptive prompt for physical AI adapted to your custom domain." \
+    --save_path output/lora_custom_data/generated_video_from_lora_post-training.mp4 \
+    --num_gpus ${NUM_GPUS} \
+    --use_lora \
+    --lora_rank 16 \
+    --lora_alpha 16 \
+    --lora_target_modules "q_proj,k_proj,v_proj,output_proj,mlp.layer1,mlp.layer2" \
+    --offload_guardrail \
+    --offload_prompt_refiner
+```
+
+#### Cosmos-Predict2-14B-Video2World with LoRA
+
+The 14B model can be run similarly by changing the `--model_size` and using the appropriate LoRA parameters:
+
+```bash
+export NUM_GPUS=8
+export PYTHONPATH=$(pwd)
+
+torchrun --nproc_per_node=${NUM_GPUS} examples/video2world_lora.py \
+    --model_size 14B \
+    --dit_path "checkpoints/posttraining/video2world_lora/14b_custom_data/checkpoints/model/iter_000001000.pt" \
+    --input_path "assets/video2world/input0.jpg" \
+    --prompt "A descriptive prompt for physical AI adapted to your custom domain." \
+    --save_path output/lora_custom_data/generated_video_from_14b_lora_post-training.mp4 \
+    --num_gpus ${NUM_GPUS} \
+    --use_lora \
+    --lora_rank 32 \
+    --lora_alpha 32 \
+    --lora_target_modules "q_proj,k_proj,v_proj,output_proj,mlp.layer1,mlp.layer2" \
+    --offload_guardrail \
+    --offload_prompt_refiner
+```
+
+#### Critical Requirements for LoRA Inference
+
+**Important**: The LoRA parameters used during inference **must match** those used during training:
+
+1. **Use the `--use_lora` flag**: This is required to enable LoRA inference mode
+2. **Match LoRA parameters**: `--lora_rank`, `--lora_alpha`, and `--lora_target_modules` must match training config
+3. **Use the LoRA inference script**: Use `video2world_lora.py` instead of `video2world.py`
+
+
+### 5. Advanced LoRA Training Configurations
+
+#### Domain-Specific LoRA Training
+
+For different domains, you can adjust LoRA parameters:
+
+**Robotics/Physical AI Domain:**
+```python
+model=dict(
+    config=dict(
+        train_architecture="lora",
+        lora_rank=24,
+        lora_alpha=24,
+        lora_target_modules="q_proj,k_proj,v_proj,output_proj,mlp.layer1,mlp.layer2",
+        # Domain-specific settings
+        max_iter=3000,
+        lr=2 ** (-9.5),
+    )
+)
+```
+
+**Surveillance/Security Domain:**
+```python
+model=dict(
+    config=dict(
+        train_architecture="lora",
+        lora_rank=16,
+        lora_alpha=16,
+        lora_target_modules="q_proj,k_proj,v_proj,output_proj",  # Attention-only for subtle changes
+        # Domain-specific settings
+        max_iter=2000,
+        lr=2 ** (-10.5),
+    )
+)
+```
+
+**Creative/Artistic Domain:**
+```python
+model=dict(
+    config=dict(
+        train_architecture="lora",
+        lora_rank=32,
+        lora_alpha=48,  # Higher alpha for stronger adaptation
+        lora_target_modules="q_proj,k_proj,v_proj,output_proj,mlp.layer1,mlp.layer2,norm1,norm2",
+        # Domain-specific settings
+        max_iter=4000,
+        lr=2 ** (-9),
+    )
+)
+```
+
+#### Multi-Dataset LoRA Training
+
+For training on multiple datasets, create combined dataloaders:
+
+```python
+# Multiple datasets
+metropolis_dataset = L(Dataset)(
+    dataset_dir="datasets/metropolis_lora",
+    num_frames=93,
+    video_size=(704, 1280),
+)
+
+robotics_dataset = L(Dataset)(
+    dataset_dir="datasets/robotics_lora",
+    num_frames=93,
+    video_size=(704, 1280),
+)
+
+# Combined dataloader
+combined_dataloader = L(DataLoader)(
+    dataset=L(ConcatDataset)([metropolis_dataset, robotics_dataset]),
+    sampler=L(get_sampler)(dataset=L(ConcatDataset)([metropolis_dataset, robotics_dataset])),
+    batch_size=2,
+    drop_last=True,
+    num_workers=8,
+    pin_memory=True,
+)
+```
+
+#### LoRA with Different Target Modules
+
+**Attention-Only (Lightweight):**
+```python
+lora_target_modules="q_proj,k_proj,v_proj,output_proj"
+```
+
+**Attention + MLP (Recommended):**
+```python
+lora_target_modules="q_proj,k_proj,v_proj,output_proj,mlp.layer1,mlp.layer2"
+```
+
+### 6. Troubleshooting LoRA Training
+
+#### Common Issues and Solutions
+
+1. **LoRA Parameters Not Found**
+   ```
+   Error: No parameters found for LoRA adaptation
+   ```
+   **Solution**: Ensure `model.config.train_architecture=lora` is set in the training command.
+
+2. **Memory Issues**
+   ```
+   CUDA out of memory
+   ```
+   **Solution**: Reduce batch size or increase context parallelism size.
+
+3. **Slow Convergence**
+   ```
+   Loss not decreasing after many iterations
+   ```
+   **Solution**: Try higher learning rate (2^(-9) to 2^(-8)) or higher LoRA rank.
+
+4. **Overfitting**
+   ```
+   Training loss decreases but validation loss increases
+   ```
+   **Solution**: Reduce LoRA rank, add data augmentation, or early stopping.
+
+## LoRA Training with Cosmos-NeMo-Assets Dataset
+
+This section provides a complete example of LoRA training using the Cosmos-NeMo-Assets dataset for physical AI applications.
+
+### Data Preparation
+
+Follow the data preparation steps from the [Cosmos-NeMo-Assets guide](post-training_video2world_cosmos_nemo_assets.md):
+
+#### 1. Download Cosmos-NeMo-Assets Dataset
+
+```bash
+mkdir -p datasets/cosmos_nemo_assets/
+
+# Download the videos for physical AI
+huggingface-cli download nvidia/Cosmos-NeMo-Assets --repo-type dataset --local-dir datasets/cosmos_nemo_assets/ --include "*.mp4*"
+
+mv datasets/cosmos_nemo_assets/nemo_diffusion_example_data datasets/cosmos_nemo_assets/videos
+```
+
+#### 2. Preprocess T5-XXL Embeddings
+
+```bash
+# Generate T5-XXL embeddings with robot-specific prompt
+PYTHONPATH=$(pwd) python scripts/get_t5_embeddings_from_cosmos_nemo_assets.py --dataset_path datasets/cosmos_nemo_assets --prompt "A video of sks teal robot."
+```
+
+This creates the required dataset structure:
+```
+datasets/cosmos_nemo_assets/
+├── metas/
+│   ├── *.txt
+├── videos/
+│   ├── *.mp4
+├── t5_xxl/
+│   ├── *.pickle
+```
+
+### LoRA Training Commands
+
+#### Video2World LoRA Training
+
+**2B Model Training:**
+```bash
+EXP=predict2_video2world_lora_training_2b_cosmos_nemo_assets
+torchrun --nproc_per_node=8 --master_port=12341 -m scripts.train \
+    --config=cosmos_predict2/configs/base/config.py \
+    -- experiment=${EXP} \
+    model.config.train_architecture=lora
+```
+
+**14B Model Training (Multi-node):**
+```bash
+EXP=predict2_video2world_lora_training_14b_cosmos_nemo_assets
+torchrun --nproc_per_node=8 --nnodes=4 --rdzv_id 123 --rdzv_backend c10d --rdzv_endpoint $MASTER_ADDR:1234 \
+    -m scripts.train \
+    --config=cosmos_predict2/configs/base/config.py \
+    -- experiment=${EXP} \
+    model.config.train_architecture=lora
+```
+
+
+
+### LoRA Configuration Details
+
+The Cosmos-NeMo-Assets LoRA configurations include the following optimizations:
+
+**For 2B Models:**
+- LoRA rank: 16, alpha: 16
+- Learning rate: 2^(-10) (higher than full fine-tuning)
+- Batch size: 2 (doubled due to LoRA memory efficiency)
+- Max iterations: 2000
+- Checkpoint interval: 400 iterations
+
+**For 14B Models:**
+- LoRA rank: 32, alpha: 32 (higher rank for larger model)
+- Learning rate: 2^(-11) (adjusted for model size)
+- Batch size: 2
+- Max iterations: 1500 (fewer iterations needed)
+- Checkpoint interval: 300 iterations
+
+### Checkpoint Structure
+
+LoRA checkpoints will be saved to:
+```
+checkpoints/posttraining/video2world_lora/2b_cosmos_nemo_assets/checkpoints/
+├── model/
+│   ├── iter_000000400.pt  # Contains base model + LoRA parameters
+│   ├── iter_000000800.pt
+│   ├── iter_000001200.pt
+│   └── ...
+├── optim/
+├── scheduler/
+├── trainer/
+├── latest_checkpoint.txt
+```
+
+For a Succesful training, you should see the logs like this:
+
+```
+[07-10 22:14:27|SUCCESS|imaginaire/trainer.py:232:train] Done with training.  
+```
+
+
+
+### LoRA Inference Commands
+
+Use the LoRA-trained checkpoints for inference:
+
+**2B Video2World LoRA Inference:**
+```bash
+export NUM_GPUS=8
+export PYTHONPATH=$(pwd)
+
+torchrun --nproc_per_node=${NUM_GPUS} examples/video2world_lora.py \
+    --model_size 2B \
+    --dit_path "checkpoints/posttraining/video2world_lora/2b_cosmos_nemo_assets/checkpoints/model/iter_000001000.pt" \
+    --input_path "assets/video2world_cosmos_nemo_assets/output_Digit_Lift_movie.jpg" \
+    --prompt "A video of sks teal robot." \
+    --save_path output/cosmos_nemo_assets_lora/generated_video_2b_lora.mp4 \
+    --num_gpus ${NUM_GPUS} \
+    --use_lora \
+    --lora_rank 16 \
+    --lora_alpha 16 \
+    --lora_target_modules "q_proj,k_proj,v_proj,output_proj,mlp.layer1,mlp.layer2" \
+    --offload_guardrail \
+    --offload_prompt_refiner
+```
+
+**14B Video2World LoRA Inference:**
+```bash
+export NUM_GPUS=8
+export PYTHONPATH=$(pwd)
+
+torchrun --nproc_per_node=${NUM_GPUS} examples/video2world_lora.py \
+    --model_size 14B \
+    --dit_path "checkpoints/posttraining/video2world_lora/14b_cosmos_nemo_assets/checkpoints/model/iter_000001000.pt" \
+    --input_path "assets/video2world_cosmos_nemo_assets/output_Digit_Lift_movie.jpg" \
+    --prompt "A video of sks teal robot." \
+    --save_path output/cosmos_nemo_assets_lora/generated_video_14b_lora.mp4 \
+    --num_gpus ${NUM_GPUS} \
+    --use_lora \
+    --lora_rank 32 \
+    --lora_alpha 32 \
+    --lora_target_modules "q_proj,k_proj,v_proj,output_proj,mlp.layer1,mlp.layer2" \
+    --offload_guardrail \
+    --offload_prompt_refiner
+```
+
+### Training Progress Monitoring
+
+During LoRA training with Cosmos-NeMo-Assets, you should see logs like:
+```
+Adding LoRA adapters: rank=16, alpha=16, targets=['q_proj', 'k_proj', 'v_proj', 'output_proj', 'mlp.layer1', 'mlp.layer2']
+Total parameters: 3.96B, Frozen parameters: 3,912,826,880, Trainable parameters: 45,875,200
+```
+
+
+## Results Comparison: Full Fine-tuning vs LoRA
+
+The following comparison demonstrates the effectiveness of LoRA post-training compared to traditional full fine-tuning using the Cosmos-Predict2-2B-Video2World model on the Cosmos-NeMo-Assets dataset.
+
+### Training Comparison
+
+| Aspect | Full Fine-tuning | LoRA Fine-tuning |
+|--------|------------------|------------------|
+| **Video Output** | <video width="320" height="240" controls><source src="../assets/video2world_lora/video2world_nemo_2b.mp4" type="video/mp4">Full fine-tuning result</video> | <video width="320" height="240" controls><source src="../assets/video2world_lora/video2world_nemo_2b_lora.mp4" type="video/mp4">LoRA fine-tuning result</video> |
+| **Trainable Parameters** | 100% | 1.2% |
+| **Checkpoint Size** | Large | Small |
+| **Learning Rate** | 2^(-14.5) | 2^(-10) |
+| **Convergence** | 3000 iterations | 1000 iterations |
+
+### Quality Analysis
+
+**LoRA Fine-tuning:**
+- Maintains base model capabilities
+- Faster adaptation to domain-specific tasks
+- More parameter-efficient
+- Better for preserving general knowledge
+
+**Full Fine-tuning:**
+- Comprehensive model adaptation
+- Potentially better fine-grained control
+- Risk of catastrophic forgetting
+- Requires higher computational resources
+
+## Related Documentation
+
+- [Video2World Inference Guide](inference_video2world.md) - Standard inference without LoRA
+- [Video2World Post-Training Guide](post-training_video2world.md) - Full model post-training
+- [Cosmos-NeMo-Assets Post-Training](post-training_video2world_cosmos_nemo_assets.md) - Original dataset guide
+- [Setup Guide](setup.md) - Environment setup and checkpoint download instructions  
+- [Performance Guide](performance.md) - Hardware requirements and optimization recommendations

--- a/examples/text2image.py
+++ b/examples/text2image.py
@@ -50,6 +50,11 @@ def parse_args() -> argparse.Namespace:
         default="",
         help="Custom path to the DiT model checkpoint for post-trained models.",
     )
+    parser.add_argument(
+        "--load_ema",
+        action="store_true",
+        help="Use EMA weights for generation.",
+    )
     parser.add_argument("--prompt", type=str, default=_DEFAULT_POSITIVE_PROMPT, help="Text prompt for image generation")
     parser.add_argument(
         "--batch_input_json",
@@ -136,6 +141,7 @@ def setup_pipeline(args: argparse.Namespace, text_encoder=None) -> Text2ImagePip
                 dit_path=dit_path,
                 device="cuda",
                 torch_dtype=torch.bfloat16,
+                load_ema_to_reg=args.load_ema,
             )
             return pipe
         else:
@@ -170,6 +176,7 @@ def setup_pipeline(args: argparse.Namespace, text_encoder=None) -> Text2ImagePip
             text_encoder_path=text_encoder_path,
             device="cuda",
             torch_dtype=torch.bfloat16,
+            load_ema_to_reg=args.load_ema,
         )
 
         # Set the provided text encoder if one was passed

--- a/examples/text2world.py
+++ b/examples/text2world.py
@@ -27,10 +27,17 @@ from cosmos_predict2.pipelines.text2image import Text2ImagePipeline
 from cosmos_predict2.pipelines.video2world import Video2WorldPipeline
 
 # Import functionality from other example scripts
-from examples.text2image import process_single_generation as process_single_image_generation
+from examples.text2image import (
+    process_single_generation as process_single_image_generation,
+)
 from examples.text2image import setup_pipeline as setup_text2image_pipeline
-from examples.video2world import _DEFAULT_NEGATIVE_PROMPT, cleanup_distributed
-from examples.video2world import process_single_generation as process_single_video_generation
+from examples.video2world import (
+    _DEFAULT_NEGATIVE_PROMPT,
+    cleanup_distributed,
+)
+from examples.video2world import (
+    process_single_generation as process_single_video_generation,
+)
 from examples.video2world import setup_pipeline as setup_video2world_pipeline
 from imaginaire.utils import log
 
@@ -105,10 +112,21 @@ def parse_args() -> argparse.Namespace:
         help="FPS of the model to use for video-to-world generation",
     )
     parser.add_argument(
-        "--dit_path",
+        "--dit_path_text2image",
         type=str,
         default="",
-        help="Custom path to the DiT model checkpoint for post-trained models.",
+        help="Custom path to the DiT model checkpoint for post-trained text2image models.",
+    )
+    parser.add_argument(
+        "--dit_path_video2world",
+        type=str,
+        default="",
+        help="Custom path to the DiT model checkpoint for post-trained video2world models.",
+    )
+    parser.add_argument(
+        "--load_ema",
+        action="store_true",
+        help="Use EMA weights for generation.",
     )
     parser.add_argument("--guidance", type=float, default=7, help="Guidance value for video generation")
     parser.add_argument("--offload_guardrail", action="store_true", help="Offload guardrail to CPU to save GPU memory")
@@ -277,6 +295,7 @@ if __name__ == "__main__":
         text_encoder = None
 
         log.info("Step 1: Initializing text2image pipeline...")
+        args.dit_path = args.dit_path_text2image
         text2image_pipe = setup_text2image_pipeline(args)
 
         # Handle the case where setup_text2image_pipeline returns None for non-rank-0 processes
@@ -309,6 +328,7 @@ if __name__ == "__main__":
             log.info(f"Rank {rank}: Will create new text encoder for video2world pipeline")
 
         # Pass all video2world relevant arguments and the text encoder
+        args.dit_path = args.dit_path_video2world
         video2world_pipe = setup_video2world_pipeline(args, text_encoder=text_encoder)
 
         # Generate videos

--- a/examples/video2world_action.py
+++ b/examples/video2world_action.py
@@ -16,7 +16,6 @@
 import argparse
 import json
 import os
-import pdb
 
 import mediapy as mp
 import numpy as np
@@ -27,9 +26,7 @@ os.environ["TOKENIZERS_PARALLELISM"] = "false"
 import torch
 from megatron.core import parallel_state
 
-from cosmos_predict2.configs.action_conditioned.config import (
-    PREDICT2_VIDEO2WORLD_PIPELINE_2B_ACTION_CONDITIONED,
-)
+from cosmos_predict2.configs.action_conditioned.config import PREDICT2_VIDEO2WORLD_PIPELINE_2B_ACTION_CONDITIONED
 from cosmos_predict2.pipelines.video2world_action import Video2WorldActionConditionedPipeline
 from imaginaire.utils import distributed, log, misc
 from imaginaire.utils.io import save_image_or_video
@@ -61,6 +58,11 @@ def parse_args() -> argparse.Namespace:
         type=str,
         default="",
         help="Custom path to the DiT model checkpoint for post-trained models.",
+    )
+    parser.add_argument(
+        "--load_ema",
+        action="store_true",
+        help="Use EMA weights for generation.",
     )
     parser.add_argument(
         "--input_video",
@@ -155,6 +157,7 @@ def setup_pipeline(args: argparse.Namespace):
         text_encoder_path=text_encoder_path,
         device="cuda",
         torch_dtype=torch.bfloat16,
+        load_ema_to_reg=args.load_ema,
         load_prompt_refiner=True,
     )
 

--- a/examples/video2world_bestofn.py
+++ b/examples/video2world_bestofn.py
@@ -222,6 +222,11 @@ def parse_args():
         help="Custom path to the DiT model checkpoint for post-trained models.",
     )
     parser.add_argument(
+        "--load_ema",
+        action="store_true",
+        help="Use EMA weights for generation.",
+    )
+    parser.add_argument(
         "--prompt",
         type=str,
         default="",

--- a/examples/video2world_gr00t.py
+++ b/examples/video2world_gr00t.py
@@ -54,6 +54,11 @@ def parse_args() -> argparse.Namespace:
         help="Custom path to the DiT model checkpoint for post-trained models.",
     )
     parser.add_argument(
+        "--load_ema",
+        action="store_true",
+        help="Use EMA weights for generation.",
+    )
+    parser.add_argument(
         "--prompt",
         type=str,
         default="",
@@ -169,6 +174,7 @@ def setup_pipeline(args: argparse.Namespace):
         text_encoder_path=text_encoder_path,
         device="cuda",
         torch_dtype=torch.bfloat16,
+        load_ema_to_reg=args.load_ema,
         load_prompt_refiner=False,  # Disable prompt refiner for GR00T
     )
 

--- a/examples/video2world_lora.py
+++ b/examples/video2world_lora.py
@@ -24,18 +24,237 @@ import time
 
 import torch
 from megatron.core import parallel_state
+from tqdm import tqdm
 
 from cosmos_predict2.configs.base.config_video2world import (
     PREDICT2_VIDEO2WORLD_PIPELINE_2B,
     PREDICT2_VIDEO2WORLD_PIPELINE_14B,
-    PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_2B,
-    PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_14B,
 )
 from cosmos_predict2.pipelines.video2world import _IMAGE_EXTENSIONS, _VIDEO_EXTENSIONS, Video2WorldPipeline
 from imaginaire.utils import distributed, log, misc
-from imaginaire.utils.io import save_image_or_video, save_text_prompts
+from imaginaire.utils.io import save_image_or_video
 
 _DEFAULT_NEGATIVE_PROMPT = "The video captures a series of frames showing ugly scenes, static with no motion, motion blur, over-saturation, shaky footage, low resolution, grainy texture, pixelated images, poorly lit areas, underexposed and overexposed scenes, poor color balance, washed out colors, choppy sequences, jerky movements, low frame rate, artifacting, color banding, unnatural transitions, outdated special effects, fake elements, unconvincing visuals, poorly edited content, jump cuts, visual noise, and flickering. Overall, the video is of poor quality."
+
+
+def add_lora_to_model(
+    model,
+    lora_rank=16,
+    lora_alpha=16,
+    lora_target_modules="q_proj,k_proj,v_proj,output_proj,mlp.layer1,mlp.layer2",
+    init_lora_weights=True,
+):
+    """
+    Add LoRA to a model using PEFT library.
+
+    Args:
+        model: The model to add LoRA to
+        lora_rank: Rank of the LoRA adaptation
+        lora_alpha: Alpha parameter for LoRA
+        lora_target_modules: Comma-separated list of target modules
+        init_lora_weights: Whether to initialize LoRA weights
+    """
+    from peft import LoraConfig, inject_adapter_in_model
+
+    lora_config = LoraConfig(
+        r=lora_rank,
+        lora_alpha=lora_alpha,
+        init_lora_weights=init_lora_weights,
+        target_modules=lora_target_modules.split(","),
+    )
+    model = inject_adapter_in_model(lora_config, model)
+
+    # Upcast LoRA parameters to fp32 for better stability
+    for param in model.parameters():
+        if param.requires_grad:
+            param.data = param.to(torch.float32)
+
+    return model
+
+
+def setup_lora_pipeline(config, dit_path, text_encoder_path, args):
+    """
+    Set up a pipeline with LoRA support.
+    This function creates the pipeline, adds LoRA, then loads the checkpoint.
+    """
+    import numpy as np
+
+    from cosmos_predict2.auxiliary.cosmos_reason1 import CosmosReason1
+    from cosmos_predict2.auxiliary.text_encoder import CosmosT5TextEncoder
+    from cosmos_predict2.models.utils import init_weights_on_device, load_state_dict
+    from cosmos_predict2.module.denoiser_scaling import RectifiedFlowScaling
+    from cosmos_predict2.schedulers.rectified_flow_scheduler import RectifiedFlowAB2Scheduler
+    from imaginaire.lazy_config import instantiate
+    from imaginaire.utils.ema import FastEmaModelUpdater
+
+    # Create a pipe
+    pipe = Video2WorldPipeline(device="cuda", torch_dtype=torch.bfloat16)
+    pipe.config = config
+    pipe.precision = {
+        "float32": torch.float32,
+        "float16": torch.float16,
+        "bfloat16": torch.bfloat16,
+    }[config.precision]
+    pipe.tensor_kwargs = {"device": "cuda", "dtype": pipe.precision}
+    log.warning(f"precision {pipe.precision}")
+
+    # 1. set data keys and data information
+    pipe.sigma_data = config.sigma_data
+    pipe.setup_data_key()
+
+    # 2. setup up diffusion processing and scaling~(pre-condition)
+    pipe.scheduler = RectifiedFlowAB2Scheduler(
+        sigma_min=config.timestamps.t_min,
+        sigma_max=config.timestamps.t_max,
+        order=config.timestamps.order,
+        t_scaling_factor=config.rectified_flow_t_scaling_factor,
+    )
+
+    pipe.scaling = RectifiedFlowScaling(pipe.sigma_data, config.rectified_flow_t_scaling_factor)
+
+    # 3. Set up tokenizer
+    pipe.tokenizer = instantiate(config.tokenizer)
+    assert (
+        pipe.tokenizer.latent_ch == pipe.config.state_ch
+    ), f"latent_ch {pipe.tokenizer.latent_ch} != state_shape {pipe.config.state_ch}"
+
+    # 4. Load text encoder
+    if text_encoder_path:
+        # inference
+        pipe.text_encoder = CosmosT5TextEncoder(device="cuda", cache_dir=text_encoder_path)
+        pipe.text_encoder.to("cuda")
+    else:
+        # training
+        pipe.text_encoder = None
+
+    # 5. Initialize conditioner
+    pipe.conditioner = instantiate(config.conditioner)
+    assert (
+        sum(p.numel() for p in pipe.conditioner.parameters() if p.requires_grad) == 0
+    ), "conditioner should not have learnable parameters"
+
+    # Load prompt refiner
+    pipe.prompt_refiner = CosmosReason1(
+        checkpoint_dir=config.prompt_refiner_config.checkpoint_dir,
+        offload_model_to_cpu=config.prompt_refiner_config.offload_model_to_cpu,
+        enabled=config.prompt_refiner_config.enabled,
+    )
+
+    if config.guardrail_config.enabled:
+        from cosmos_predict2.auxiliary.guardrail.common import presets as guardrail_presets
+
+        pipe.text_guardrail_runner = guardrail_presets.create_text_guardrail_runner(
+            config.guardrail_config.checkpoint_dir, config.guardrail_config.offload_model_to_cpu
+        )
+        pipe.video_guardrail_runner = guardrail_presets.create_video_guardrail_runner(
+            config.guardrail_config.checkpoint_dir, config.guardrail_config.offload_model_to_cpu
+        )
+    else:
+        pipe.text_guardrail_runner = None
+        pipe.video_guardrail_runner = None
+
+    # 6. Set up DiT WITHOUT loading checkpoint first
+    log.info("Initializing DiT model...")
+    with init_weights_on_device():
+        dit_config = config.net
+        pipe.dit = instantiate(dit_config).eval()  # inference
+
+    # 7. Add LoRA to the DiT model BEFORE loading checkpoint
+    log.info("Adding LoRA to the DiT model...")
+    log.info(
+        f"LoRA parameters: rank={args.lora_rank}, alpha={args.lora_alpha}, target_modules={args.lora_target_modules}"
+    )
+
+    pipe.dit = add_lora_to_model(
+        pipe.dit,
+        lora_rank=args.lora_rank,
+        lora_alpha=args.lora_alpha,
+        lora_target_modules=args.lora_target_modules,
+        init_lora_weights=args.init_lora_weights,
+    )
+
+    # 8. Handle EMA model if enabled
+    if config.ema.enabled:
+        log.info("Setting up EMA model...")
+        pipe.dit_ema = instantiate(dit_config).eval()
+        pipe.dit_ema.requires_grad_(False)
+
+        # Add LoRA to EMA model
+        log.info("Adding LoRA to the EMA DiT model...")
+        pipe.dit_ema = add_lora_to_model(
+            pipe.dit_ema,
+            lora_rank=args.lora_rank,
+            lora_alpha=args.lora_alpha,
+            lora_target_modules=args.lora_target_modules,
+            init_lora_weights=args.init_lora_weights,
+        )
+
+        pipe.dit_ema_worker = FastEmaModelUpdater()  # default when not using FSDP
+
+        s = config.ema.rate
+        pipe.ema_exp_coefficient = np.roots([1, 7, 16 - s**-2, 12 - s**-2]).real.max()
+        # copying is only necessary when starting the training at iteration 0.
+        # Actual state_dict should be loaded after the pipe is created.
+        pipe.dit_ema_worker.copy_to(src_model=pipe.dit, tgt_model=pipe.dit_ema)
+
+    # 9. NOW load the LoRA checkpoint with strict=False
+    if dit_path:
+        log.info(f"Loading LoRA checkpoint from {dit_path}")
+        state_dict = load_state_dict(dit_path)
+
+        # Split state dict for regular and EMA models
+        state_dict_dit_regular = dict()
+        state_dict_dit_ema = dict()
+
+        for k, v in state_dict.items():
+            if k.startswith("net."):
+                state_dict_dit_regular[k[4:]] = v
+            elif k.startswith("net_ema."):
+                state_dict_dit_ema[k[4:]] = v
+
+        # Load regular model with strict=False to allow LoRA weights
+        log.info("Loading regular DiT model weights...")
+        missing_keys = pipe.dit.load_state_dict(state_dict_dit_regular, strict=False, assign=True)
+        if missing_keys.missing_keys:
+            log.warning(f"Missing keys in regular model: {missing_keys.missing_keys}")
+        if missing_keys.unexpected_keys:
+            log.warning(f"Unexpected keys in regular model: {missing_keys.unexpected_keys}")
+
+        # Load EMA model if enabled
+        if config.ema.enabled and state_dict_dit_ema:
+            log.info("Loading EMA DiT model weights...")
+            missing_keys_ema = pipe.dit_ema.load_state_dict(state_dict_dit_ema, strict=False, assign=True)
+            if missing_keys_ema.missing_keys:
+                log.warning(f"Missing keys in EMA model: {missing_keys_ema.missing_keys}")
+            if missing_keys_ema.unexpected_keys:
+                log.warning(f"Unexpected keys in EMA model: {missing_keys_ema.unexpected_keys}")
+
+        del state_dict, state_dict_dit_regular, state_dict_dit_ema
+        log.success(f"Successfully loaded LoRA checkpoint from {dit_path}")
+    else:
+        log.warning("No checkpoint path provided, using random weights")
+
+    # 10. Move models to device
+    pipe.dit = pipe.dit.to(device="cuda", dtype=torch.bfloat16)
+    if config.ema.enabled:
+        pipe.dit_ema = pipe.dit_ema.to(device="cuda", dtype=torch.bfloat16)
+
+    torch.cuda.empty_cache()
+
+    # 11. Set up training states
+    if parallel_state.is_initialized():
+        pipe.data_parallel_size = parallel_state.get_data_parallel_world_size()
+    else:
+        pipe.data_parallel_size = 1
+
+    # Print parameter counts
+    total_params = sum(p.numel() for p in pipe.dit.parameters())
+    trainable_params = sum(p.numel() for p in pipe.dit.parameters() if p.requires_grad)
+    log.info(f"Total parameters: {total_params:,}")
+    log.info(f"Trainable LoRA parameters: {trainable_params:,}")
+    log.info(f"LoRA parameter ratio: {trainable_params/total_params*100:.2f}%")
+
+    return pipe
 
 
 def validate_input_file(input_path: str, num_conditional_frames: int) -> bool:
@@ -69,7 +288,7 @@ def validate_input_file(input_path: str, num_conditional_frames: int) -> bool:
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Video-to-World Generation with Cosmos Predict2")
+    parser = argparse.ArgumentParser(description="Video-to-World Generation with Cosmos Predict2 (LoRA Support)")
     parser.add_argument(
         "--model_size",
         choices=["2B", "14B"],
@@ -96,11 +315,38 @@ def parse_args() -> argparse.Namespace:
         default="",
         help="Custom path to the DiT model checkpoint for post-trained models.",
     )
+
+    # LoRA-specific arguments
     parser.add_argument(
-        "--load_ema",
+        "--use_lora",
         action="store_true",
-        help="Use EMA weights for generation.",
+        help="Enable LoRA inference mode",
     )
+    parser.add_argument(
+        "--lora_rank",
+        type=int,
+        default=16,
+        help="Rank of the LoRA adaptation",
+    )
+    parser.add_argument(
+        "--lora_alpha",
+        type=int,
+        default=16,
+        help="Alpha parameter for LoRA",
+    )
+    parser.add_argument(
+        "--lora_target_modules",
+        type=str,
+        default="q_proj,k_proj,v_proj,output_proj,mlp.layer1,mlp.layer2",
+        help="Comma-separated list of target modules for LoRA",
+    )
+    parser.add_argument(
+        "--init_lora_weights",
+        action="store_true",
+        default=True,
+        help="Whether to initialize LoRA weights",
+    )
+
     parser.add_argument(
         "--prompt",
         type=str,
@@ -118,13 +364,6 @@ def parse_args() -> argparse.Namespace:
         type=str,
         default=_DEFAULT_NEGATIVE_PROMPT,
         help="Negative text prompt for video-to-world generation",
-    )
-    parser.add_argument(
-        "--aspect_ratio",
-        choices=["1:1", "4:3", "3:4", "16:9", "9:16"],
-        default="16:9",
-        type=str,
-        help="Aspect ratio of the generated output (width:height)",
     )
     parser.add_argument(
         "--num_conditional_frames",
@@ -166,41 +405,12 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Run the generation in benchmark mode. It means that generation will be rerun a few times and the average generation time will be shown.",
     )
-    parser.add_argument("--use_cuda_graphs", action="store_true", help="Use CUDA Graphs for the text2image inference.")
-    parser.add_argument(
-        "--natten",
-        action="store_true",
-        help="Run Video2World + NATTEN (sparse attention variant).",
-    )
     return parser.parse_args()
 
 
 def setup_pipeline(args: argparse.Namespace, text_encoder=None):
     log.info(f"Using model size: {args.model_size}")
-    if hasattr(args, "natten") and args.natten:
-        assert args.model_size in ["2B", "14B"]
-        config = (
-            PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_2B
-            if args.model_size == "2B"
-            else PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_14B
-        )
-
-        config.resolution = args.resolution
-
-        if args.fps == 10:
-            config.state_t = 16
-
-        if args.resolution != "720":
-            raise NotImplementedError("Cosmos-Predict2 + NATTEN only supports 720p inference at the moment.")
-
-        if args.aspect_ratio != "16:9":
-            raise NotImplementedError("Cosmos-Predict2 + NATTEN only supports 16:9 aspect ratio at the moment.")
-
-        dit_path = (
-            f"checkpoints/nvidia/Cosmos-Predict2-{args.model_size}-Video2World/model-720p-{args.fps}fps-natten.pt"
-        )
-
-    elif args.model_size == "2B":
+    if args.model_size == "2B":
         config = PREDICT2_VIDEO2WORLD_PIPELINE_2B
 
         config.resolution = args.resolution
@@ -218,13 +428,13 @@ def setup_pipeline(args: argparse.Namespace, text_encoder=None):
         dit_path = f"checkpoints/nvidia/Cosmos-Predict2-14B-Video2World/model-{args.resolution}p-{args.fps}fps.pt"
     else:
         raise ValueError("Invalid model size. Choose either '2B' or '14B'.")
+
     if hasattr(args, "dit_path") and args.dit_path:
         dit_path = args.dit_path
 
-    log.info(f"Using dit_path: {dit_path}")
-
     # Only set up text encoder path if no encoder is provided
     text_encoder_path = None if text_encoder is not None else "checkpoints/google-t5/t5-11b"
+    log.info(f"Using dit_path: {dit_path}")
     if text_encoder is not None:
         log.info("Using provided text encoder")
     else:
@@ -269,17 +479,23 @@ def setup_pipeline(args: argparse.Namespace, text_encoder=None):
         config.prompt_refiner_config.enabled = False
     config.prompt_refiner_config.offload_model_to_cpu = args.offload_prompt_refiner
 
-    # Load models
+    # Load models - for LoRA, we need to handle this differently
     log.info(f"Initializing Video2WorldPipeline with model size: {args.model_size}")
-    pipe = Video2WorldPipeline.from_config(
-        config=config,
-        dit_path=dit_path,
-        text_encoder_path=text_encoder_path,
-        device="cuda",
-        torch_dtype=torch.bfloat16,
-        load_ema_to_reg=args.load_ema,
-        load_prompt_refiner=True,
-    )
+
+    if args.use_lora:
+        # For LoRA inference, we need to add LoRA before loading the checkpoint
+        log.info("LoRA inference mode detected - using custom pipeline loading")
+        pipe = setup_lora_pipeline(config, dit_path, text_encoder_path, args)
+    else:
+        # Standard inference
+        pipe = Video2WorldPipeline.from_config(
+            config=config,
+            dit_path=dit_path,
+            text_encoder_path=text_encoder_path,
+            device="cuda",
+            torch_dtype=torch.bfloat16,
+            load_prompt_refiner=True,
+        )
 
     # Set the provided text encoder if one was passed
     if text_encoder is not None:
@@ -289,18 +505,8 @@ def setup_pipeline(args: argparse.Namespace, text_encoder=None):
 
 
 def process_single_generation(
-    pipe: Video2WorldPipeline,
-    input_path: str,
-    prompt: str,
-    output_path: str,
-    negative_prompt: str,
-    aspect_ratio: str,
-    num_conditional_frames: int,
-    guidance: float,
-    seed: int,
-    benchmark: bool = False,
-    use_cuda_graphs: bool = False,
-) -> bool:
+    pipe, input_path, prompt, output_path, negative_prompt, num_conditional_frames, guidance, seed, benchmark
+):
     # Validate input file
     if not validate_input_file(input_path, num_conditional_frames):
         log.warning(f"Input file validation failed: {input_path}")
@@ -314,50 +520,32 @@ def process_single_generation(
         if benchmark and i > 0:
             torch.cuda.synchronize()
             start_time = time.time()
-        video, prompt_used = pipe(
+        video = pipe(
             prompt=prompt,
             negative_prompt=negative_prompt,
-            aspect_ratio=aspect_ratio,
             input_path=input_path,
             num_conditional_frames=num_conditional_frames,
             guidance=guidance,
             seed=seed,
-            use_cuda_graphs=use_cuda_graphs,
-            return_prompt=True,
         )
         if benchmark and i > 0:
             torch.cuda.synchronize()
-            elapsed = time.time() - start_time
-            time_sum += elapsed
-            log.info(f"[iter {i} / {num_repeats - 1}] Generation time: {elapsed:.1f} seconds.")
+            time_sum += time.time() - start_time
     if benchmark:
-        time_avg = time_sum / (num_repeats - 1)
-        log.critical(f"Average generation time for Video2WorldPipeline is {time_avg:.1f} seconds.")
+        log.critical(f"The benchmarked generation time for Video2WorldPipeline is {time_sum / 3} seconds.")
 
     if video is not None:
         # save the generated video
         output_dir = os.path.dirname(output_path)
         if output_dir:
             os.makedirs(output_dir, exist_ok=True)
-        log.info(f"Saving the generated video to: {output_path}")
+        log.info(f"Saving generated video to: {output_path}")
         if pipe.config.state_t == 16:
             fps = 10
         else:
             fps = 16
         save_image_or_video(video, output_path, fps=fps)
         log.success(f"Successfully saved video to: {output_path}")
-        # save the prompts used to generate the video
-        output_prompt_path = os.path.splitext(output_path)[0] + ".txt"
-        prompts_to_save = {"prompt": prompt, "negative_prompt": negative_prompt}
-        if (
-            pipe.prompt_refiner is not None
-            and getattr(pipe.config, "prompt_refiner_config", None) is not None
-            and getattr(pipe.config.prompt_refiner_config, "enabled", False)
-        ):
-            prompts_to_save["refined_prompt"] = prompt_used
-        save_text_prompts(prompts_to_save, output_prompt_path)
-        log.success(f"Successfully saved prompt file to: {output_prompt_path}")
-
         return True
     return False
 
@@ -374,8 +562,7 @@ def generate_video(args: argparse.Namespace, pipe: Video2WorldPipeline) -> None:
         with open(args.batch_input_json, "r") as f:
             batch_inputs = json.load(f)
 
-        for idx, item in enumerate(batch_inputs):
-            log.info(f"Processing batch item {idx + 1}/{len(batch_inputs)}")
+        for idx, item in enumerate(tqdm(batch_inputs)):
             input_video = item.get("input_video", "")
             prompt = item.get("prompt", "")
             output_video = item.get("output_video", f"output_{idx}.mp4")
@@ -390,12 +577,10 @@ def generate_video(args: argparse.Namespace, pipe: Video2WorldPipeline) -> None:
                 prompt=prompt,
                 output_path=output_video,
                 negative_prompt=args.negative_prompt,
-                aspect_ratio=args.aspect_ratio,
                 num_conditional_frames=args.num_conditional_frames,
                 guidance=args.guidance,
                 seed=args.seed,
                 benchmark=args.benchmark,
-                use_cuda_graphs=args.use_cuda_graphs,
             )
     else:
         process_single_generation(
@@ -404,12 +589,10 @@ def generate_video(args: argparse.Namespace, pipe: Video2WorldPipeline) -> None:
             prompt=args.prompt,
             output_path=args.save_path,
             negative_prompt=args.negative_prompt,
-            aspect_ratio=args.aspect_ratio,
             num_conditional_frames=args.num_conditional_frames,
             guidance=args.guidance,
             seed=args.seed,
             benchmark=args.benchmark,
-            use_cuda_graphs=args.use_cuda_graphs,
         )
 
     return

--- a/examples/video2world_lvg.py
+++ b/examples/video2world_lvg.py
@@ -86,6 +86,11 @@ def parse_args() -> argparse.Namespace:
         help="Custom path to the DiT model checkpoint for post-trained models.",
     )
     parser.add_argument(
+        "--load_ema",
+        action="store_true",
+        help="Use EMA weights for generation.",
+    )
+    parser.add_argument(
         "--prompt",
         type=str,
         default="",
@@ -198,6 +203,7 @@ def setup_pipeline(args: argparse.Namespace):
         text_encoder_path=text_encoder_path,
         device="cuda",
         torch_dtype=torch.bfloat16,
+        load_ema_to_reg=args.load_ema,
         load_prompt_refiner=True,
     )
 

--- a/imaginaire/datasets/webdataset/config/schema.py
+++ b/imaginaire/datasets/webdataset/config/schema.py
@@ -18,7 +18,6 @@ from typing import Optional, Type
 import attrs
 from torch.utils.data import IterableDataset
 
-from imaginaire import config
 from imaginaire.config import make_freezable
 from imaginaire.datasets.webdataset.augmentors.augmentor import Augmentor
 

--- a/imaginaire/datasets/webdataset/utils/iterators.py
+++ b/imaginaire/datasets/webdataset/utils/iterators.py
@@ -15,9 +15,7 @@
 
 import io
 import os
-import random
 import sys
-import time
 from typing import IO, Any, BinaryIO, Callable, Dict, Iterable, Iterator, Optional, Tuple, Union
 from urllib.parse import urlparse
 

--- a/imaginaire/datasets/webdataset/webdataset.py
+++ b/imaginaire/datasets/webdataset/webdataset.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import pickle
 from collections.abc import Iterable
 from functools import partial

--- a/imaginaire/utils/callback.py
+++ b/imaginaire/utils/callback.py
@@ -21,7 +21,6 @@ from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import omegaconf
 import torch
-import torch.distributed as dist
 import torch.utils.data
 import tqdm
 

--- a/imaginaire/utils/device.py
+++ b/imaginaire/utils/device.py
@@ -13,12 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import gc
 import math
 import os
 
 import pynvml
-from loguru import logger as logging
 
 
 class Device:

--- a/imaginaire/utils/ema.py
+++ b/imaginaire/utils/ema.py
@@ -15,8 +15,7 @@
 
 from __future__ import annotations
 
-from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Generator, List, Optional, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 import numpy as np
 import torch
@@ -314,24 +313,3 @@ class PowerEMATracker(EMAModelTracker):
         if cur_dp_rank < num:
             print(f"PowerEMATracker: rank {cur_dp_rank}, rate {rate / divider}")
         return cls(model, rate / divider)
-
-
-@contextmanager
-def ema_scope(model: ImaginaireModel, enabled: bool = False) -> Generator[None, None, None]:
-    """Context manager for switching between regular and EMA model weights.
-
-    Args:
-        model (ImaginaireModel): The PyTorch model.
-        enabled (bool): Whether switching to EMA weights is enabled (default: False).
-    """
-    if enabled:
-        assert hasattr(model, "ema") and isinstance(model.ema, (FastEmaModelUpdater, EMAModelTracker, PowerEMATracker))
-        model.ema.cache(model.parameters())
-        model.ema.copy_to(model)
-        log.info("EMA: switched to EMA weights.")
-    try:
-        yield None
-    finally:
-        if enabled:
-            model.ema.restore(model.parameters())
-            log.info("EMA: restored regular weights.")

--- a/scripts/extract_images_from_videos.py
+++ b/scripts/extract_images_from_videos.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import os
 

--- a/scripts/test_environment.py
+++ b/scripts/test_environment.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import importlib
-import os
 import sys
 
 
@@ -49,7 +48,7 @@ def check_packages(package_list, success_status=True):
                 version = getattr(module, "__version__", None)
                 print_success(package, version)
                 try:
-                    from apex import multi_tensor_apply
+                    from apex import multi_tensor_apply  # noqa: F401
 
                     print_success("apex.multi_tensor_apply")
                 except ImportError:
@@ -64,7 +63,7 @@ def check_packages(package_list, success_status=True):
                 version = getattr(module, "__version__", None)
                 print_success(package, version)
                 try:
-                    import transformer_engine.pytorch
+                    import transformer_engine.pytorch  # noqa: F401
 
                     print_success("transformer_engine.pytorch")
                 except ImportError:


### PR DESCRIPTION
# Predict2 Video2World LoRA Post-Training Guide

This guide provides instructions on running LoRA (Low-Rank Adaptation) post-training with Cosmos-Predict2 Video2World models.

## Table of Contents
- [Prerequisites](#prerequisites)
- [Overview](#overview)
- [Post-training Guide](#post-training-guide)

## Prerequisites

Before running LoRA post-training:

1. **Environment setup**: Follow the [Setup guide](setup.md) for installation instructions.
2. **Model checkpoints**: Download required model weights following the [Downloading Checkpoints](setup.md#downloading-checkpoints) section in the Setup guide.
3. **Hardware considerations**: Review the [Performance guide](performance.md) for GPU requirements and model selection recommendations.
4. **PEFT library**: The LoRA training uses the PEFT (Parameter-Efficient Fine-Tuning) library which should be installed as part of the environment setup.

## Overview

Cosmos-Predict2 provides two models for generating videos from a combination of text and visual inputs: `Cosmos-Predict2-2B-Video2World` and `Cosmos-Predict2-14B-Video2World`. These models can transform a still image or video clip into a longer, animated sequence guided by the text description.

LoRA (Low-Rank Adaptation) is a parameter-efficient fine-tuning technique that allows you to adapt large pre-trained models to specific domains or tasks by training only a small number of additional parameters. This approach offers several advantages:

### Key Benefits of LoRA Post-Training

- **Memory Efficiency**: Only trains a small subset of parameters (typically < 1% of total model parameters)
- **Faster Training**: Significantly reduced training time compared to full fine-tuning
- **Storage Efficiency**: LoRA checkpoints are much smaller than full model checkpoints
- **Flexibility**: Can maintain multiple LoRA adapters for different domains
- **Preserved Base Capabilities**: Retains the original model's capabilities while adding domain-specific improvements

We support LoRA post-training with example datasets:
- [post-training_video2world_cosmos_nemo_assets](/documentations/post-training_video2world_cosmos_nemo_assets.md)
  - Basic examples with a small 4 videos dataset (can be adapted for LoRA)
- [post-training_video2world_agibot_fisheye](/documentations/post-training_video2world_agibot_fisheye.md)
  - Examples with fisheye-view dataset (can be adapted for LoRA)
- [post-training_video2world_gr00t](/documentations/post-training_video2world_gr00t.md)
  - Examples with GR00T-dreams datasets (can be adapted for LoRA)

### Cosmos-NeMo-Assets LoRA Configurations

We provide dedicated LoRA configurations for Cosmos-NeMo-Assets in `cosmos_predict2/configs/base/experiment/cosmos_nemo_assets_lora.py`:
- `predict2_video2world_lora_training_2b_cosmos_nemo_assets` - 2B model LoRA training
- `predict2_video2world_lora_training_14b_cosmos_nemo_assets` - 14B model LoRA training

## Post-training Guide

### 1. Preparing Data

The LoRA post-training data preparation follows the same format as standard post-training.

Dataset folder format:
```
datasets/custom_video2world_lora_dataset/
├── metas/
│   ├── *.txt
├── videos/
│   ├── *.mp4
```

`metas` folder contains `.txt` files containing prompts describing the video content.
`videos` folder contains the corresponding `.mp4` video files.

After preparing `metas` and `videos` folders, run the following command to pre-compute T5-XXL embeddings:
```bash
python -m scripts.get_t5_embeddings --dataset_path datasets/custom_video2world_lora_dataset/
```

This script will create `t5_xxl` folder under the dataset root where the T5-XXL embeddings are saved as `.pickle` files:
```
datasets/custom_video2world_lora_dataset/
├── metas/
│   ├── *.txt
├── videos/
│   ├── *.mp4
├── t5_xxl/
│   ├── *.pickle
```

### 2. Creating Configs for LoRA Training

Define dataloader from the prepared dataset with LoRA-specific configurations.

For example:
```python
# custom LoRA dataset example
example_video_lora_dataset = L(Dataset)(
    dataset_dir="datasets/custom_video2world_lora_dataset",
    num_frames=93,
    video_size=(704, 1280),  # 720 resolution, 16:9 aspect ratio
)

dataloader_video_train_lora = L(DataLoader)(
    dataset=example_video_lora_dataset,
    sampler=L(get_sampler)(dataset=example_video_lora_dataset),
    batch_size=2,  # Can use larger batch size due to memory efficiency
    drop_last=True,
    num_workers=8,
    pin_memory=True,
)
```

With the `dataloader_video_train_lora`, create a config for a LoRA training job.
Here's a LoRA post-training example for video2world 2B model:

```python
predict2_video2world_lora_training_2b_custom_data = dict(
    defaults=[
        {"override /model": "predict2_video2world_fsdp_2b"},
        {"override /optimizer": "fusedadamw"},
        {"override /scheduler": "lambdalinear"},
        {"override /ckpt_type": "standard"},
        {"override /dataloader_val": "mock"},
        "_self_",
    ],
    job=dict(
        project="posttraining",
        group="video2world_lora",
        name="2b_custom_data",
    ),
    model=dict(
        config=dict(
            # Enable LoRA training
            train_architecture="lora",
            # LoRA configuration parameters
            lora_rank=16,
            lora_alpha=16,
            lora_target_modules="q_proj,k_proj,v_proj,output_proj,mlp.layer1,mlp.layer2",
            init_lora_weights=True,
            pipe_config=dict(
                ema=dict(enabled=True),     # enable EMA during training
                prompt_refiner_config=dict(enabled=False),  # disable prompt refiner during training
                guardrail_config=dict(enabled=False),   # disable guardrail during training
            ),
        )
    ),
    model_parallel=dict(
        context_parallel_size=2,            # context parallelism size
    ),
    dataloader_train=dataloader_video_train_lora,
    trainer=dict(
        distributed_parallelism="fsdp",
        callbacks=dict(
            iter_speed=dict(hit_thres=10),
        ),
        max_iter=2000,                      # LoRA typically needs more iterations but trains faster
    ),
    checkpoint=dict(
        save_iter=500,                      # checkpoints will be saved every 500 iterations.
    ),
    optimizer=dict(
        lr=2 ** (-10),                      # LoRA typically uses higher learning rates
    ),
    scheduler=dict(
        warm_up_steps=[0],
        cycle_lengths=[2_000],              # adjust considering max_iter
        f_max=[0.6],
        f_min=[0.0],
    ),
)
```

Here's a LoRA post-training example for video2world 14B model:

```python
predict2_video2world_lora_training_14b_custom_data = dict(
    defaults=[
        {"override /model": "predict2_video2world_fsdp_14b"},
        {"override /optimizer": "fusedadamw"},
        {"override /scheduler": "lambdalinear"},
        {"override /ckpt_type": "standard"},
        {"override /dataloader_val": "mock"},
        "_self_",
    ],
    job=dict(
        project="posttraining",
        group="video2world_lora",
        name="14b_custom_data",
    ),
    model=dict(
        config=dict(
            # Enable LoRA training
            train_architecture="lora",
            # LoRA configuration parameters
            lora_rank=32,                    # Higher rank for larger model
            lora_alpha=32,
            lora_target_modules="q_proj,k_proj,v_proj,output_proj,mlp.layer1,mlp.layer2",
            init_lora_weights=True,
            pipe_config=dict(
                ema=dict(enabled=True),     # enable EMA during training
                prompt_refiner_config=dict(enabled=False),  # disable prompt refiner during training
                guardrail_config=dict(enabled=False),   # disable guardrail during training
            ),
        )
    ),
    model_parallel=dict(
        context_parallel_size=4,
    ),
    dataloader_train=dataloader_video_train_lora,
    trainer=dict(
        distributed_parallelism="fsdp",
        callbacks=dict(
            iter_speed=dict(hit_thres=10),
        ),
        max_iter=1500,
    ),
    checkpoint=dict(
        save_iter=300,
    ),
    optimizer=dict(
        lr=2 ** (-11),
    ),
    scheduler=dict(
        warm_up_steps=[0],
        cycle_lengths=[1_500],
        f_max=[0.6],
        f_min=[0.0],
    ),
)
```

The config should be registered to ConfigStore:
```python
for _item in [
    # 2b, custom LoRA data
    predict2_video2world_lora_training_2b_custom_data,
    # 14b, custom LoRA data
    predict2_video2world_lora_training_14b_custom_data,
]:
    # Get the experiment name from the global variable.
    experiment_name = [name.lower() for name, value in globals().items() if value is _item][0]

    cs.store(
        group="experiment",
        package="_global_",
        name=experiment_name,
        node=_item,
    )
```

### 2.1. LoRA Configuration Parameters

The key LoRA-specific parameters in the config are:

| Parameter | Description | Default | Recommended Values |
|-----------|-------------|---------|-------------------|
| `train_architecture` | Set to "lora" to enable LoRA training | "full" | **"lora"** (required) |
| `lora_rank` | Rank of LoRA adaptation matrices | 16 | 8-32 (2B), 16-64 (14B) |
| `lora_alpha` | LoRA scaling parameter | 16 | Usually equals lora_rank |
| `lora_target_modules` | Target modules for LoRA adaptation | "q_proj,k_proj,v_proj,output_proj,mlp.layer1,mlp.layer2" | Comma-separated module names |
| `init_lora_weights` | Initialize LoRA weights properly | True | Keep as True |

#### LoRA Parameter Guidelines

**For 2B Model:**
- **Conservative**: rank=8, alpha=8, lr=2^(-12)
- **Balanced**: rank=16, alpha=16, lr=2^(-10) 
- **Aggressive**: rank=32, alpha=32, lr=2^(-9)

**For 14B Model:**
- **Conservative**: rank=16, alpha=16, lr=2^(-12)
- **Balanced**: rank=32, alpha=32, lr=2^(-11)
- **Aggressive**: rank=64, alpha=64, lr=2^(-10)

### 2.2. Config System

In the above config example, it starts by overriding from the registered configs:
```python
    {"override /model": "predict2_video2world_fsdp_2b"},
    {"override /optimizer": "fusedadamw"},
    {"override /scheduler": "lambdalinear"},
    {"override /ckpt_type": "standard"},
    {"override /dataloader_val": "mock"},
```

The configuration system is organized as follows:

```
cosmos_predict2/configs/base/
├── config.py                   # Main configuration class definition
├── defaults/                   # Default configuration groups
│   ├── callbacks.py            # Training callbacks configurations
│   ├── checkpoint.py           # Checkpoint saving/loading configurations
│   ├── data.py                 # Dataset and dataloader configurations
│   ├── ema.py                  # Exponential Moving Average configurations
│   ├── model.py                # Model architecture configurations
│   ├── optimizer.py            # Optimizer configurations
│   └── scheduler.py            # Learning rate scheduler configurations
└── experiment/                 # Experiment-specific configurations
    ├── cosmos_nemo_assets.py   # Experiments with cosmos_nemo_assets
    ├── agibot_head_center_fisheye_color.py  # Experiments with agibot_head_center_fisheye_color
    ├── groot.py                # Experiments with groot
    └── utils.py                # Utility functions for experiments
```

The system provides several pre-defined configuration groups that can be mixed and matched:

#### Model Configurations (`defaults/model.py`)
- `predict2_video2world_fsdp_2b`: 2B parameter Video2World model with FSDP
- `predict2_video2world_fsdp_14b`: 14B parameter Video2World model with FSDP

Both can be used with LoRA by setting `train_architecture="lora"` in the model config.

#### Optimizer Configurations (`defaults/optimizer.py`)
- `fusedadamw`: FusedAdamW optimizer with standard settings
- Custom optimizer configurations for different training scenarios

LoRA typically uses higher learning rates than full fine-tuning.

#### Scheduler Configurations (`defaults/scheduler.py`)
- `constant`: Constant learning rate
- `lambdalinear`: Linearly warming-up learning rate
- Various learning rate scheduling strategies

#### Data Configurations (`defaults/data.py`)
- Training and validation dataset configurations

#### Checkpoint Configurations (`defaults/checkpoint.py`)
- `standard`: Standard local checkpoint handling

#### Callback Configurations (`defaults/callbacks.py`)
- `basic`: Essential training callbacks
- Performance monitoring and logging callbacks

In addition to the overridden values, the rest of the config setup overwrites or adds the other config details.

### 3. Run a LoRA Training Job

Run the following command to execute a LoRA post-training job with the custom data:

#### For 2B Model:
```bash
EXP=predict2_video2world_lora_training_2b_custom_data
torchrun --nproc_per_node=8 --master_port=12341 -m scripts.train \
    --config=cosmos_predict2/configs/base/config.py \
    -- experiment=${EXP} \
    model.config.train_architecture=lora
```

#### For 14B Model:
```bash
EXP=predict2_video2world_lora_training_14b_custom_data
torchrun --nproc_per_node=8 --master_port=12341 -m scripts.train \
    --config=cosmos_predict2/configs/base/config.py \
    -- experiment=${EXP} \
    model.config.train_architecture=lora
```

The `model.config.train_architecture=lora` parameter explicitly enables LoRA training mode.

#### Training Progress Monitoring

During LoRA training, you'll see parameter statistics like:
```
Total parameters: 3.96B, 
Frozen parameters: 3,912,826,880, 
Trainable parameters: 45,875,200
```

This confirms that only a small fraction of parameters are being trained.

The LoRA checkpoints will be saved to `checkpoints/PROJECT/GROUP/NAME`.
In the above example, `PROJECT` is `posttraining`, `GROUP` is `video2world_lora`, `NAME` is `2b_custom_data`.

```
checkpoints/posttraining/video2world_lora/2b_custom_data/checkpoints/
├── model/
│   ├── iter_{NUMBER}.pt  # Contains base model + LoRA parameters
├── optim/
├── scheduler/
├── trainer/
├── latest_checkpoint.txt
```

### 4. Run Inference on LoRA Post-trained Checkpoints

LoRA post-trained checkpoints require special handling during inference. Use the dedicated `video2world_lora.py` script:

#### Cosmos-Predict2-2B-Video2World with LoRA

For example, if a LoRA post-trained checkpoint with 1000 iterations is to be used, run the following command:

```bash
export NUM_GPUS=8
export PYTHONPATH=$(pwd)

torchrun --nproc_per_node=${NUM_GPUS} examples/video2world_lora.py \
    --model_size 2B \
    --dit_path "checkpoints/posttraining/video2world_lora/2b_custom_data/checkpoints/model/iter_000001000.pt" \
    --input_path "assets/video2world/input0.jpg" \
    --prompt "A descriptive prompt for physical AI adapted to your custom domain." \
    --save_path output/lora_custom_data/generated_video_from_lora_post-training.mp4 \
    --num_gpus ${NUM_GPUS} \
    --use_lora \
    --lora_rank 16 \
    --lora_alpha 16 \
    --lora_target_modules "q_proj,k_proj,v_proj,output_proj,mlp.layer1,mlp.layer2" \
    --offload_guardrail \
    --offload_prompt_refiner
```

#### Cosmos-Predict2-14B-Video2World with LoRA

The 14B model can be run similarly by changing the `--model_size` and using the appropriate LoRA parameters:

```bash
export NUM_GPUS=8
export PYTHONPATH=$(pwd)

torchrun --nproc_per_node=${NUM_GPUS} examples/video2world_lora.py \
    --model_size 14B \
    --dit_path "checkpoints/posttraining/video2world_lora/14b_custom_data/checkpoints/model/iter_000001000.pt" \
    --input_path "assets/video2world/input0.jpg" \
    --prompt "A descriptive prompt for physical AI adapted to your custom domain." \
    --save_path output/lora_custom_data/generated_video_from_14b_lora_post-training.mp4 \
    --num_gpus ${NUM_GPUS} \
    --use_lora \
    --lora_rank 32 \
    --lora_alpha 32 \
    --lora_target_modules "q_proj,k_proj,v_proj,output_proj,mlp.layer1,mlp.layer2" \
    --offload_guardrail \
    --offload_prompt_refiner
```

#### Critical Requirements for LoRA Inference

**Important**: The LoRA parameters used during inference **must match** those used during training:

1. **Use the `--use_lora` flag**: This is required to enable LoRA inference mode
2. **Match LoRA parameters**: `--lora_rank`, `--lora_alpha`, and `--lora_target_modules` must match training config
3. **Use the LoRA inference script**: Use `video2world_lora.py` instead of `video2world.py`


### 5. Advanced LoRA Training Configurations

#### Domain-Specific LoRA Training

For different domains, you can adjust LoRA parameters:

**Robotics/Physical AI Domain:**
```python
model=dict(
    config=dict(
        train_architecture="lora",
        lora_rank=24,
        lora_alpha=24,
        lora_target_modules="q_proj,k_proj,v_proj,output_proj,mlp.layer1,mlp.layer2",
        # Domain-specific settings
        max_iter=3000,
        lr=2 ** (-9.5),
    )
)
```

**Surveillance/Security Domain:**
```python
model=dict(
    config=dict(
        train_architecture="lora",
        lora_rank=16,
        lora_alpha=16,
        lora_target_modules="q_proj,k_proj,v_proj,output_proj",  # Attention-only for subtle changes
        # Domain-specific settings
        max_iter=2000,
        lr=2 ** (-10.5),
    )
)
```

**Creative/Artistic Domain:**
```python
model=dict(
    config=dict(
        train_architecture="lora",
        lora_rank=32,
        lora_alpha=48,  # Higher alpha for stronger adaptation
        lora_target_modules="q_proj,k_proj,v_proj,output_proj,mlp.layer1,mlp.layer2,norm1,norm2",
        # Domain-specific settings
        max_iter=4000,
        lr=2 ** (-9),
    )
)
```

#### Multi-Dataset LoRA Training

For training on multiple datasets, create combined dataloaders:

```python
# Multiple datasets
metropolis_dataset = L(Dataset)(
    dataset_dir="datasets/metropolis_lora",
    num_frames=93,
    video_size=(704, 1280),
)

robotics_dataset = L(Dataset)(
    dataset_dir="datasets/robotics_lora",
    num_frames=93,
    video_size=(704, 1280),
)

# Combined dataloader
combined_dataloader = L(DataLoader)(
    dataset=L(ConcatDataset)([metropolis_dataset, robotics_dataset]),
    sampler=L(get_sampler)(dataset=L(ConcatDataset)([metropolis_dataset, robotics_dataset])),
    batch_size=2,
    drop_last=True,
    num_workers=8,
    pin_memory=True,
)
```

#### LoRA with Different Target Modules

**Attention-Only (Lightweight):**
```python
lora_target_modules="q_proj,k_proj,v_proj,output_proj"
```

**Attention + MLP (Recommended):**
```python
lora_target_modules="q_proj,k_proj,v_proj,output_proj,mlp.layer1,mlp.layer2"
```

### 6. Troubleshooting LoRA Training

#### Common Issues and Solutions

1. **LoRA Parameters Not Found**
   ```
   Error: No parameters found for LoRA adaptation
   ```
   **Solution**: Ensure `model.config.train_architecture=lora` is set in the training command.

2. **Memory Issues**
   ```
   CUDA out of memory
   ```
   **Solution**: Reduce batch size or increase context parallelism size.

3. **Slow Convergence**
   ```
   Loss not decreasing after many iterations
   ```
   **Solution**: Try higher learning rate (2^(-9) to 2^(-8)) or higher LoRA rank.

4. **Overfitting**
   ```
   Training loss decreases but validation loss increases
   ```
   **Solution**: Reduce LoRA rank, add data augmentation, or early stopping.

## LoRA Training with Cosmos-NeMo-Assets Dataset

This section provides a complete example of LoRA training using the Cosmos-NeMo-Assets dataset for physical AI applications.

### Data Preparation

Follow the data preparation steps from the [Cosmos-NeMo-Assets guide](post-training_video2world_cosmos_nemo_assets.md):

#### 1. Download Cosmos-NeMo-Assets Dataset

```bash
mkdir -p datasets/cosmos_nemo_assets/

# Download the videos for physical AI
huggingface-cli download nvidia/Cosmos-NeMo-Assets --repo-type dataset --local-dir datasets/cosmos_nemo_assets/ --include "*.mp4*"

mv datasets/cosmos_nemo_assets/nemo_diffusion_example_data datasets/cosmos_nemo_assets/videos
```

#### 2. Preprocess T5-XXL Embeddings

```bash
# Generate T5-XXL embeddings with robot-specific prompt
PYTHONPATH=$(pwd) python scripts/get_t5_embeddings_from_cosmos_nemo_assets.py --dataset_path datasets/cosmos_nemo_assets --prompt "A video of sks teal robot."
```

This creates the required dataset structure:
```
datasets/cosmos_nemo_assets/
├── metas/
│   ├── *.txt
├── videos/
│   ├── *.mp4
├── t5_xxl/
│   ├── *.pickle
```

### LoRA Training Commands

#### Video2World LoRA Training

**2B Model Training:**
```bash
EXP=predict2_video2world_lora_training_2b_cosmos_nemo_assets
torchrun --nproc_per_node=8 --master_port=12341 -m scripts.train \
    --config=cosmos_predict2/configs/base/config.py \
    -- experiment=${EXP} \
    model.config.train_architecture=lora
```

**14B Model Training (Multi-node):**
```bash
EXP=predict2_video2world_lora_training_14b_cosmos_nemo_assets
torchrun --nproc_per_node=8 --nnodes=4 --rdzv_id 123 --rdzv_backend c10d --rdzv_endpoint $MASTER_ADDR:1234 \
    -m scripts.train \
    --config=cosmos_predict2/configs/base/config.py \
    -- experiment=${EXP} \
    model.config.train_architecture=lora
```



### LoRA Configuration Details

The Cosmos-NeMo-Assets LoRA configurations include the following optimizations:

**For 2B Models:**
- LoRA rank: 16, alpha: 16
- Learning rate: 2^(-10) (higher than full fine-tuning)
- Batch size: 2 (doubled due to LoRA memory efficiency)
- Max iterations: 2000
- Checkpoint interval: 400 iterations

**For 14B Models:**
- LoRA rank: 32, alpha: 32 (higher rank for larger model)
- Learning rate: 2^(-11) (adjusted for model size)
- Batch size: 2
- Max iterations: 1500 (fewer iterations needed)
- Checkpoint interval: 300 iterations

### Checkpoint Structure

LoRA checkpoints will be saved to:
```
checkpoints/posttraining/video2world_lora/2b_cosmos_nemo_assets/checkpoints/
├── model/
│   ├── iter_000000400.pt  # Contains base model + LoRA parameters
│   ├── iter_000000800.pt
│   ├── iter_000001200.pt
│   └── ...
├── optim/
├── scheduler/
├── trainer/
├── latest_checkpoint.txt
```

For a Succesful training, you should see the logs like this:

```
[07-10 22:14:27|SUCCESS|imaginaire/trainer.py:232:train] Done with training.   
```



### LoRA Inference Commands

Use the LoRA-trained checkpoints for inference:

**2B Video2World LoRA Inference:**
```bash
export NUM_GPUS=8
export PYTHONPATH=$(pwd)

torchrun --nproc_per_node=${NUM_GPUS} examples/video2world_lora.py \
    --model_size 2B \
    --dit_path "checkpoints/posttraining/video2world_lora/2b_cosmos_nemo_assets/checkpoints/model/iter_000001000.pt" \
    --input_path "assets/video2world_cosmos_nemo_assets/output_Digit_Lift_movie.jpg" \
    --prompt "A video of sks teal robot." \
    --save_path output/cosmos_nemo_assets_lora/generated_video_2b_lora.mp4 \
    --num_gpus ${NUM_GPUS} \
    --use_lora \
    --lora_rank 16 \
    --lora_alpha 16 \
    --lora_target_modules "q_proj,k_proj,v_proj,output_proj,mlp.layer1,mlp.layer2" \
    --offload_guardrail \
    --offload_prompt_refiner
```

**14B Video2World LoRA Inference:**
```bash
export NUM_GPUS=8
export PYTHONPATH=$(pwd)

torchrun --nproc_per_node=${NUM_GPUS} examples/video2world_lora.py \
    --model_size 14B \
    --dit_path "checkpoints/posttraining/video2world_lora/14b_cosmos_nemo_assets/checkpoints/model/iter_000001000.pt" \
    --input_path "assets/video2world_cosmos_nemo_assets/output_Digit_Lift_movie.jpg" \
    --prompt "A video of sks teal robot." \
    --save_path output/cosmos_nemo_assets_lora/generated_video_14b_lora.mp4 \
    --num_gpus ${NUM_GPUS} \
    --use_lora \
    --lora_rank 32 \
    --lora_alpha 32 \
    --lora_target_modules "q_proj,k_proj,v_proj,output_proj,mlp.layer1,mlp.layer2" \
    --offload_guardrail \
    --offload_prompt_refiner
```

### Training Progress Monitoring

During LoRA training with Cosmos-NeMo-Assets, you should see logs like:
```
Adding LoRA adapters: rank=16, alpha=16, targets=['q_proj', 'k_proj', 'v_proj', 'output_proj', 'mlp.layer1', 'mlp.layer2']
Total parameters: 3.96B, Frozen parameters: 3,912,826,880, Trainable parameters: 45,875,200
```


## Results Comparison: Full Fine-tuning vs LoRA

The following comparison demonstrates the effectiveness of LoRA post-training compared to traditional full fine-tuning using the Cosmos-Predict2-2B-Video2World model on the Cosmos-NeMo-Assets dataset.

### Training Comparison

| Aspect | Full Fine-tuning | LoRA Fine-tuning |
|--------|------------------|------------------|
| **Video Output** | <video width="320" height="240" controls><source src="../assets/video2world_lora/video2world_nemo_2b.mp4" type="video/mp4">Full fine-tuning result</video> | <video width="320" height="240" controls><source src="../assets/video2world_lora/video2world_nemo_2b_lora.mp4" type="video/mp4">LoRA fine-tuning result</video> |
| **Trainable Parameters** | 100% | 1.2% |
| **Checkpoint Size** | Large | Small |
| **Learning Rate** | 2^(-14.5) | 2^(-10) |
| **Convergence** | 3000 iterations | 1000 iterations |

### Quality Analysis

**LoRA Fine-tuning:**
- Maintains base model capabilities
- Faster adaptation to domain-specific tasks
- More parameter-efficient
- Better for preserving general knowledge

**Full Fine-tuning:**
- Comprehensive model adaptation
- Potentially better fine-grained control
- Risk of catastrophic forgetting
- Requires higher computational resources

## Related Documentation

- [Video2World Inference Guide](inference_video2world.md) - Standard inference without LoRA
- [Video2World Post-Training Guide](post-training_video2world.md) - Full model post-training
- [Cosmos-NeMo-Assets Post-Training](post-training_video2world_cosmos_nemo_assets.md) - Original dataset guide
- [Setup Guide](setup.md) - Environment setup and checkpoint download instructions  
- [Performance Guide](performance.md) - Hardware requirements and optimization recommendations
