### PR TITLE
oom fix for conda environment when loading a checkpoint

### DIFF
--- a/cosmos_predict2/checkpointer.py
+++ b/cosmos_predict2/checkpointer.py
@@ -237,6 +237,7 @@ class Checkpointer:
                         strict=False if model.config.train_architecture == "lora" else True,
                     ),
                 )
+                del state_dicts_to_load_for_dit_reg
                 # Load EMA weights.
                 if model.pipe.config.ema.enabled:
                     set_model_state_dict(
@@ -248,6 +249,7 @@ class Checkpointer:
                             strict=False if model.config.train_architecture == "lora" else True,
                         ),
                     )
+                del state_dicts_to_load_for_dit_ema
 
                 # Restore the attention operators.
                 model.pipe.apply_cp()


### PR DESCRIPTION
#59 14B video2world training resume runs fine with docker but fails when executed with a conda environment.
It is difficult to find the root cause of the issue but it is fixable by removing some variables after using them.
