### PR TITLE
Upgrade NATTEN to 0.21.0

### DIFF
--- a/documentations/setup.md
+++ b/documentations/setup.md
@@ -61,7 +61,7 @@ Please make sure you have access to Docker on your machine and the [NVIDIA Conta
 
    ```bash
    # Pull the Cosmos-Predict2 container
-   docker pull nvcr.io/nvidia/cosmos/cosmos-predict2-container:1.1
+   docker pull nvcr.io/nvidia/cosmos/cosmos-predict2-container:1.2
    ```
 
 * **Option 2B: Build container from Dockerfile**
@@ -74,7 +74,7 @@ Please make sure you have access to Docker on your machine and the [NVIDIA Conta
 
 * **Running the container**
 
-   Use the following command to run either container, replacing `[CONTAINER_NAME]` with either `nvcr.io/nvidia/cosmos/cosmos-predict2-container:1.1` or `cosmos-predict2-local`:
+   Use the following command to run either container, replacing `[CONTAINER_NAME]` with either `nvcr.io/nvidia/cosmos/cosmos-predict2-container:1.2` or `cosmos-predict2-local`:
 
    ```bash
    # Run the container with GPU support and mount necessary directories

--- a/documentations/setup.md
+++ b/documentations/setup.md
@@ -39,7 +39,7 @@ ln -sf $CONDA_PREFIX/lib/python3.10/site-packages/nvidia/*/include/* $CONDA_PREF
 ln -sf $CONDA_PREFIX/lib/python3.10/site-packages/nvidia/*/include/* $CONDA_PREFIX/include/python3.10
 CUDA_HOME=$CONDA_PREFIX pip install transformer-engine[pytorch]==1.13.0
 # NATTEN
-CUDA_HOME=$CONDA_PREFIX pip install natten==0.20.1
+CUDA_HOME=$CONDA_PREFIX pip install natten==0.21.0
 
 # Apex library for training (optional if inference only)
 CUDA_HOME=$CONDA_PREFIX pip install -v --disable-pip-version-check --no-cache-dir --no-build-isolation --config-settings "--build-option=--cpp_ext --cuda_ext" git+https://github.com/NVIDIA/apex.git

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -14,7 +14,7 @@ loguru==0.7.3
 mediapy==1.2.4
 megatron-core==0.12.1
 modelscope==1.26.0
-natten==0.20.1
+natten==0.21.0
 nltk==3.9.1
 omegaconf==2.3.0
 opencv-python==4.11.0.86


### PR DESCRIPTION
Upgrades NATTEN to the latest release, and unblocks backprop with NATTEN on Hopper and Blackwell.