### PR TITLE
PICBIR9W-1121: Add checkpoint revisions.

### DIFF
--- a/documentations/setup.md
+++ b/documentations/setup.md
@@ -17,6 +17,7 @@ cd cosmos-predict2
 ```
 
 ### ARM installation
+
 When using an ARM platform, like GB200, special steps are required to install the `decord` package.
 You need to make sure that [NVIDIA Video Codec SDK](https://developer.nvidia.com/nvidia-video-codec-sdk/download) is downloaded in the root of the repository.
 The installation will be handled by the Conda scripts or Dockerfile.
@@ -25,15 +26,26 @@ The installation will be handled by the Conda scripts or Dockerfile.
 
 Install system dependencies:
 
-```sh
-# Install uv/just
-curl -LsSf https://astral.sh/uv/install.sh | sh
-source $HOME/.local/bin/env
-uv tool install rust-just
+* [uv](https://docs.astral.sh/uv/getting-started/installation/)
 
-# Try to install decord when on ARM platform
-bash scripts/install_decord_arm.sh
-```
+  ```shell
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  source $HOME/.local/bin/env
+  ```
+
+* [just](https://github.com/casey/just?tab=readme-ov-file#installation)
+
+  ```shell
+  pkgm install just
+  # or
+  conda install -c conda-forge just
+  ```
+
+* [arm only] decord
+
+   ```sh
+   bash scripts/install_decord_arm.sh
+   ```
 
 Install the package using your preferred environment:
 
@@ -41,7 +53,7 @@ Install the package using your preferred environment:
 
    Install system dependencies:
 
-   * conda: https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html
+   * conda: <https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html>
 
    ```sh
    just install-conda
@@ -52,7 +64,7 @@ Install the package using your preferred environment:
 
    Install system dependencies:
 
-   * CUDA 12.6: https://developer.nvidia.com/cuda-12-6-0-download-archive
+   * CUDA 12.6: <https://developer.nvidia.com/cuda-12-6-0-download-archive>
    * clang
 
    ```sh
@@ -80,6 +92,7 @@ Please make sure you have access to Docker on your machine and the [NVIDIA Conta
 * **Option 2B: Build container from Dockerfile**
 
    Make sure you are under the repo root.
+
    ```bash
    # Build the Docker image
    docker build -t cosmos-predict2-local -f Dockerfile .
@@ -105,53 +118,58 @@ Please make sure you have access to Docker on your machine and the [NVIDIA Conta
 
 ## Downloading Checkpoints
 
-1. Get a [Hugging Face](https://huggingface.co/settings/tokens) access token with `Read` permission
-2. Login: `huggingface-cli login`
-3. The [Llama-Guard-3-8B terms](https://huggingface.co/meta-llama/Llama-Guard-3-8B) must be accepted. Approval will be required before Llama Guard 3 can be downloaded.
-4. Download models:
+1. Get a [Hugging Face Access Token](https://huggingface.co/settings/tokens) with `Read` permission
+2. Install [Hugging Face CLI](https://huggingface.co/docs/huggingface_hub/en/guides/cli): `uv tool install -U "huggingface_hub[cli]"`
+3. Login: `hf auth login`
+4. The [Llama-Guard-3-8B terms](https://huggingface.co/meta-llama/Llama-Guard-3-8B) must be accepted. Approval will be required before Llama Guard 3 can be downloaded.
+5. Download models:
 
 | Models | Link | Download Command | Notes |
 |--------|------|------------------|-------|
-| Cosmos-Predict2-0.6B-Text2Image | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-0.6B-Text2Image) | `python -m scripts.download_checkpoints --model_types text2image --model_sizes 0.6B` | N/A |
-| Cosmos-Predict2-2B-Text2Image | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-2B-Text2Image) | `python -m scripts.download_checkpoints --model_types text2image --model_sizes 2B` | N/A |
-| Cosmos-Predict2-14B-Text2Image | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-14B-Text2Image) | `python -m scripts.download_checkpoints --model_types text2image --model_sizes 14B` | N/A |
-| Cosmos-Predict2-2B-Video2World | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-2B-Video2World) | `python -m scripts.download_checkpoints --model_types video2world --model_sizes 2B` | Download 720P, 16FPS by default. Supports 480P and 720P resolution. Supports 10FPS and 16FPS |
-| Cosmos-Predict2-14B-Video2World | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-14B-Video2World) | `python -m scripts.download_checkpoints --model_types video2world --model_sizes 14B` | Download 720P, 16FPS by default. Supports 480P and 720P resolution. Supports 10FPS and 16FPS |
-| Cosmos-Predict2-2B-Sample-Action-Conditioned | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-2B-Sample-Action-Conditioned) | `python -m scripts.download_checkpoints --model_types sample_action_conditioned` | Supports 480P and 4FPS. |
-| Cosmos-Predict2-14B-Sample-GR00T-Dreams-GR1 | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-14B-Sample-GR00T-Dreams-GR1) | `python -m scripts.download_checkpoints --model_types sample_gr00t_dreams_gr1` | Supports 480P and 16FPS. |
-| Cosmos-Predict2-14B-Sample-GR00T-Dreams-DROID | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-14B-Sample-GR00T-Dreams-DROID) | `python -m scripts.download_checkpoints --model_types sample_gr00t_dreams_droid` | Supports 480P and 16FPS. |
-
+| Cosmos-Predict2-0.6B-Text2Image | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-0.6B-Text2Image) | `./scripts/download_checkpoints.py --model_types text2image --model_sizes 0.6B` | N/A |
+| Cosmos-Predict2-2B-Text2Image | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-2B-Text2Image) | `./scripts/download_checkpoints.py --model_types text2image --model_sizes 2B` | N/A |
+| Cosmos-Predict2-14B-Text2Image | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-14B-Text2Image) | `./scripts/download_checkpoints.py --model_types text2image --model_sizes 14B` | N/A |
+| Cosmos-Predict2-2B-Video2World | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-2B-Video2World) | `./scripts/download_checkpoints.py --model_types video2world --model_sizes 2B` | Download 720P, 16FPS by default. Supports 480P and 720P resolution. Supports 10FPS and 16FPS |
+| Cosmos-Predict2-14B-Video2World | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-14B-Video2World) | `./scripts/download_checkpoints.py --model_types video2world --model_sizes 14B` | Download 720P, 16FPS by default. Supports 480P and 720P resolution. Supports 10FPS and 16FPS |
+| Cosmos-Predict2-2B-Sample-Action-Conditioned | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-2B-Sample-Action-Conditioned) | `./scripts/download_checkpoints.py --model_types sample_action_conditioned` | Supports 480P and 4FPS. |
+| Cosmos-Predict2-14B-Sample-GR00T-Dreams-GR1 | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-14B-Sample-GR00T-Dreams-GR1) | `./scripts/download_checkpoints.py --model_types sample_gr00t_dreams_gr1` | Supports 480P and 16FPS. |
+| Cosmos-Predict2-14B-Sample-GR00T-Dreams-DROID | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-14B-Sample-GR00T-Dreams-DROID) | `./scripts/download_checkpoints.py --model_types sample_gr00t_dreams_droid` | Supports 480P and 16FPS. |
 
 For Video2World model with different resolution and FPS, you can pass `resolution` and `fps` flag to control which model checkpoint to download. For example, if you want a 2B model with 480P and 10FPS, you can do
+
 ```bash
-python -m scripts.download_checkpoints --model_types video2world --model_sizes 2B --resolution 480 --fps 10
+./scripts/download_checkpoints.py --model_types video2world --model_sizes 2B --resolution 480 --fps 10
 ```
 
 Tips: `model_types`, `model_sizes`, `fps` and `resolution` supports multiple values. So if you want a mega command to download {2,14}B Video2World models with {10,16} FPS and {480,720}P, you can download 2x2x2=8 models via
+
 ```bash
-python -m scripts.download_checkpoints --model_types video2world --model_sizes 2B 14B --resolution 480 720 --fps 10 16
+./scripts/download_checkpoints.py --model_types video2world --model_sizes 2B 14B --resolution 480 720 --fps 10 16
 ```
 
 You can pass `--checkpoint_dir <path to ckpt>` if you want to control where to put the checkpoints.
-You can also add `--verify_md5` flag to verify MD5 checksums of downloaded files. If checksums don't match, models will be automatically redownloaded.
 
 To download models with [sparse attention](performance.md#sparse-attention-powered-by-natten), run the
 script with the `--natten` option:
 
 ```bash
-python -m scripts.download_checkpoints --model_types video2world --model_sizes 2B 14B --resolution 720 --fps 10 16 --natten
+./scripts/download_checkpoints.py --model_types video2world --model_sizes 2B 14B --resolution 720 --fps 10 16 --natten
 ```
 
 ## Troubleshooting
 
 ### CUDA/GPU Issues
-- **CUDA driver version insufficient**: Update NVIDIA drivers to latest version compatible with CUDA 12.6+
-- **Out of Memory (OOM) errors**: Use 2B models instead of 14B, or reduce batch size/resolution
-- **Missing CUDA libraries**: Set paths with `export CUDA_HOME=$CONDA_PREFIX`
+
+* **CUDA driver version insufficient**: Update NVIDIA drivers to latest version compatible with CUDA 12.6+
+
+* **Out of Memory (OOM) errors**: Use 2B models instead of 14B, or reduce batch size/resolution
+* **Missing CUDA libraries**: Set paths with `export CUDA_HOME=$CONDA_PREFIX`
 
 ### Installation Issues
-- **Conda environment conflicts**: Create fresh environment with `conda create -n cosmos-predict2-clean python=3.10 -y`
-- **Flash-attention build failures**: Install build tools with `apt-get install build-essential`
-- **Transformer engine linking errors**: Reinstall with `pip install --force-reinstall transformer-engine==1.12.0`
+
+* **Conda environment conflicts**: Create fresh environment with `conda create -n cosmos-predict2-clean python=3.10 -y`
+
+* **Flash-attention build failures**: Install build tools with `apt-get install build-essential`
+* **Transformer engine linking errors**: Reinstall with `pip install --force-reinstall transformer-engine==1.12.0`
 
 For other issues, check [GitHub Issues](https://github.com/nvidia-cosmos/cosmos-predict2/issues).

--- a/documentations/setup.md
+++ b/documentations/setup.md
@@ -111,6 +111,7 @@ Please make sure you have access to Docker on your machine and the [NVIDIA Conta
    [CONTAINER_NAME]
 
    # Verify setup inside container
+   export PYTHONPATH=$(pwd)
    python /workspace/scripts/test_environment.py
    ```
 
@@ -121,39 +122,31 @@ Please make sure you have access to Docker on your machine and the [NVIDIA Conta
 1. Get a [Hugging Face Access Token](https://huggingface.co/settings/tokens) with `Read` permission
 2. Install [Hugging Face CLI](https://huggingface.co/docs/huggingface_hub/en/guides/cli): `uv tool install -U "huggingface_hub[cli]"`
 3. Login: `hf auth login`
-4. The [Llama-Guard-3-8B terms](https://huggingface.co/meta-llama/Llama-Guard-3-8B) must be accepted. Approval will be required before Llama Guard 3 can be downloaded.
-5. Download models:
+4. Accept the [Llama-Guard-3-8B terms](https://huggingface.co/meta-llama/Llama-Guard-3-8B).
 
-| Models | Link | Download Command | Notes |
-|--------|------|------------------|-------|
-| Cosmos-Predict2-0.6B-Text2Image | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-0.6B-Text2Image) | `./scripts/download_checkpoints.py --model_types text2image --model_sizes 0.6B` | N/A |
-| Cosmos-Predict2-2B-Text2Image | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-2B-Text2Image) | `./scripts/download_checkpoints.py --model_types text2image --model_sizes 2B` | N/A |
-| Cosmos-Predict2-14B-Text2Image | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-14B-Text2Image) | `./scripts/download_checkpoints.py --model_types text2image --model_sizes 14B` | N/A |
-| Cosmos-Predict2-2B-Video2World | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-2B-Video2World) | `./scripts/download_checkpoints.py --model_types video2world --model_sizes 2B` | Download 720P, 16FPS by default. Supports 480P and 720P resolution. Supports 10FPS and 16FPS |
-| Cosmos-Predict2-14B-Video2World | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-14B-Video2World) | `./scripts/download_checkpoints.py --model_types video2world --model_sizes 14B` | Download 720P, 16FPS by default. Supports 480P and 720P resolution. Supports 10FPS and 16FPS |
-| Cosmos-Predict2-2B-Sample-Action-Conditioned | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-2B-Sample-Action-Conditioned) | `./scripts/download_checkpoints.py --model_types sample_action_conditioned` | Supports 480P and 4FPS. |
-| Cosmos-Predict2-14B-Sample-GR00T-Dreams-GR1 | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-14B-Sample-GR00T-Dreams-GR1) | `./scripts/download_checkpoints.py --model_types sample_gr00t_dreams_gr1` | Supports 480P and 16FPS. |
-| Cosmos-Predict2-14B-Sample-GR00T-Dreams-DROID | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-14B-Sample-GR00T-Dreams-DROID) | `./scripts/download_checkpoints.py --model_types sample_gr00t_dreams_droid` | Supports 480P and 16FPS. |
+To download a specific model:
 
-For Video2World model with different resolution and FPS, you can pass `resolution` and `fps` flag to control which model checkpoint to download. For example, if you want a 2B model with 480P and 10FPS, you can do
+| Models | Link | Download Arguments | Notes |
+|--------|------|--------------------|-------|
+| Cosmos-Predict2-0.6B-Text2Image | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-0.6B-Text2Image) | `--model_types text2image --model_sizes 0.6B` | N/A |
+| Cosmos-Predict2-2B-Text2Image | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-2B-Text2Image) | `--model_types text2image --model_sizes 2B` | N/A |
+| Cosmos-Predict2-14B-Text2Image | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-14B-Text2Image) | `--model_types text2image --model_sizes 14B` | N/A |
+| Cosmos-Predict2-2B-Video2World | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-2B-Video2World) | `--model_types video2world --model_sizes 2B` | Download 720P, 16FPS by default. Supports 480P and 720P resolution. Supports 10FPS and 16FPS |
+| Cosmos-Predict2-14B-Video2World | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-14B-Video2World) | `--model_types video2world --model_sizes 14B` | Download 720P, 16FPS by default. Supports 480P and 720P resolution. Supports 10FPS and 16FPS |
+| Cosmos-Predict2-2B-Sample-Action-Conditioned | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-2B-Sample-Action-Conditioned) | `--model_types sample_action_conditioned` | Supports 480P and 4FPS. |
+| Cosmos-Predict2-14B-Sample-GR00T-Dreams-GR1 | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-14B-Sample-GR00T-Dreams-GR1) | `--model_types sample_gr00t_dreams_gr1` | Supports 480P and 16FPS. |
+| Cosmos-Predict2-14B-Sample-GR00T-Dreams-DROID | [🤗 Huggingface](https://huggingface.co/nvidia/Cosmos-Predict2-14B-Sample-GR00T-Dreams-DROID) | `--model_types sample_gr00t_dreams_droid` | Supports 480P and 16FPS. |
 
-```bash
-./scripts/download_checkpoints.py --model_types video2world --model_sizes 2B --resolution 480 --fps 10
+To download all the checkpoints (requires ~250GB of disk space), run:
+
+```shell
+./scripts/download_checkpoints.py
 ```
 
-Tips: `model_types`, `model_sizes`, `fps` and `resolution` supports multiple values. So if you want a mega command to download {2,14}B Video2World models with {10,16} FPS and {480,720}P, you can download 2x2x2=8 models via
+To see the full list of options, run:
 
-```bash
-./scripts/download_checkpoints.py --model_types video2world --model_sizes 2B 14B --resolution 480 720 --fps 10 16
-```
-
-You can pass `--checkpoint_dir <path to ckpt>` if you want to control where to put the checkpoints.
-
-To download models with [sparse attention](performance.md#sparse-attention-powered-by-natten), run the
-script with the `--natten` option:
-
-```bash
-./scripts/download_checkpoints.py --model_types video2world --model_sizes 2B 14B --resolution 720 --fps 10 16 --natten
+```shell
+./scripts/download_checkpoints.py --help
 ```
 
 ## Troubleshooting

--- a/scripts/download_checkpoints.py
+++ b/scripts/download_checkpoints.py
@@ -31,26 +31,30 @@ from huggingface_hub import snapshot_download
 
 """Download NVIDIA Cosmos Predict2 diffusion models from Hugging Face."""
 
-MODEL_SIZE_MAPPING = {"0.6B": "Cosmos-Predict2-0.6B", "2B": "Cosmos-Predict2-2B", "14B": "Cosmos-Predict2-14B"}
+MODEL_SIZE_MAPPING = {
+    "0.6B": "Cosmos-Predict2-0.6B",
+    "2B": "Cosmos-Predict2-2B",
+    "14B": "Cosmos-Predict2-14B",
+}
 MODEL_TYPE_MAPPING = {
+    "multiview": "Multiview",
+    "sample_gr00t_dreams_droid": "Sample-GR00T-Dreams-DROID",
+    "sample_gr00t_dreams_gr1": "Sample-GR00T-Dreams-GR1",
     "text2image": "Text2Image",
     "video2world": "Video2World",
-    "sample_gr00t_dreams_gr1": "Sample-GR00T-Dreams-GR1",
-    "sample_gr00t_dreams_droid": "Sample-GR00T-Dreams-DROID",
-    "multiview": "Multiview",
 }
 REPO_ID_MAPPING = {
-    "nvidia/Cosmos-Predict2-2B-Text2Image": "acdb5fde992a73ef0355f287977d002cbfd127e0",
-    "nvidia/Cosmos-Predict2-14B-Text2Image": "015332720f70dd7b497c1cff9fd0c936a77f160b",
-    "nvidia/Cosmos-Predict2-2B-Video2World": "f50c09f5d8ab133a90cac3f4886a6471e9ba3f18",
-    "nvidia/Cosmos-Predict2-14B-Video2World": "03b03a377fede782647afac998f674d9f358e319",
-    "nvidia/Cosmos-Reason1-7B": "8fe96c1fa10db9e666b6fa6a87fea57dd9635649",
-    "nvidia/Cosmos-Predict2-2B-Multiview": "52f3731663eecdc998d9608f9b21ac4dcbdea6f1",
-    "nvidia/Cosmos-Predict2-14B-Sample-GR00T-Dreams-GR1": "926f34dd83860c5406ab4b400e156c3fd6fe6c0d",
-    "nvidia/Cosmos-Predict2-14B-Sample-GR00T-Dreams-DROID": "ebc29d30a3fab504bcc779a85bca073d14ad39f9",
     "google-t5/t5-11b": "90f37703b3334dfe9d2b009bfcbfbf1ac9d28ea3",
-    "nvidia/Cosmos-Guardrail1": "d6d4bfa899a71454a700907664f3e88f503950cf",
     "meta-llama/Llama-Guard-3-8B": "7327bd9f6efbbe6101dc6cc4736302b3cbb6e425",
+    "nvidia/Cosmos-Guardrail1": "d6d4bfa899a71454a700907664f3e88f503950cf",
+    "nvidia/Cosmos-Predict2-14B-Sample-GR00T-Dreams-DROID": "ebc29d30a3fab504bcc779a85bca073d14ad39f9",
+    "nvidia/Cosmos-Predict2-14B-Sample-GR00T-Dreams-GR1": "926f34dd83860c5406ab4b400e156c3fd6fe6c0d",
+    "nvidia/Cosmos-Predict2-14B-Text2Image": "015332720f70dd7b497c1cff9fd0c936a77f160b",
+    "nvidia/Cosmos-Predict2-14B-Video2World": "03b03a377fede782647afac998f674d9f358e319",
+    "nvidia/Cosmos-Predict2-2B-Multiview": "52f3731663eecdc998d9608f9b21ac4dcbdea6f1",
+    "nvidia/Cosmos-Predict2-2B-Text2Image": "acdb5fde992a73ef0355f287977d002cbfd127e0",
+    "nvidia/Cosmos-Predict2-2B-Video2World": "f50c09f5d8ab133a90cac3f4886a6471e9ba3f18",
+    "nvidia/Cosmos-Reason1-7B": "8fe96c1fa10db9e666b6fa6a87fea57dd9635649",
 }
 
 
@@ -61,7 +65,7 @@ def parse_args():
         nargs="*",
         default=["2B", "14B"],
         choices=["0.6B", "2B", "14B"],
-        help="Which model sizes to download. Possible values: 2B, 14B",
+        help="Which model sizes to download.",
     )
     parser.add_argument(
         "--model_types",
@@ -82,21 +86,21 @@ def parse_args():
             "sample_gr00t_dreams_droid",
             "multiview",
         ],
-        help="Which model types to download. Possible values: text2image, video2world, sample_action_conditioned",
+        help="Which model types to download.",
     )
     parser.add_argument(
         "--fps",
         nargs="*",
         default=["16"],
-        choices=["16", "10"],
-        help="Which fps to download. Possible values: 16, 10. This is only for Video2World models and will be ignored for other model_types",
+        choices=["10", "16"],
+        help="Which fps to download. This is only for Video2World models and will be ignored for other model_types",
     )
     parser.add_argument(
         "--resolution",
         nargs="*",
         default=["720"],
         choices=["480", "720"],
-        help="Which resolution to download. Possible values: 480, 720. This is only for Video2World models and will be ignored for other model_types",
+        help="Which resolution to download. This is only for Video2World models and will be ignored for other model_types",
     )
     parser.add_argument(
         "--checkpoint_dir", type=str, default="checkpoints", help="Directory to save the downloaded checkpoints."

--- a/scripts/download_checkpoints.py
+++ b/scripts/download_checkpoints.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env -S uv run --script
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -13,16 +14,48 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "huggingface-hub",
+# ]
+# [tool.uv]
+# exclude-newer = "2025-08-05T00:00:00Z"
+# ///
+
 import argparse
-import fnmatch
-import hashlib
 import os
 
+import huggingface_hub
 from huggingface_hub import snapshot_download
+
+"""Download NVIDIA Cosmos Predict2 diffusion models from Hugging Face."""
+
+MODEL_SIZE_MAPPING = {"0.6B": "Cosmos-Predict2-0.6B", "2B": "Cosmos-Predict2-2B", "14B": "Cosmos-Predict2-14B"}
+MODEL_TYPE_MAPPING = {
+    "text2image": "Text2Image",
+    "video2world": "Video2World",
+    "sample_gr00t_dreams_gr1": "Sample-GR00T-Dreams-GR1",
+    "sample_gr00t_dreams_droid": "Sample-GR00T-Dreams-DROID",
+    "multiview": "Multiview",
+}
+REPO_ID_MAPPING = {
+    "nvidia/Cosmos-Predict2-2B-Text2Image": "acdb5fde992a73ef0355f287977d002cbfd127e0",
+    "nvidia/Cosmos-Predict2-14B-Text2Image": "015332720f70dd7b497c1cff9fd0c936a77f160b",
+    "nvidia/Cosmos-Predict2-2B-Video2World": "f50c09f5d8ab133a90cac3f4886a6471e9ba3f18",
+    "nvidia/Cosmos-Predict2-14B-Video2World": "03b03a377fede782647afac998f674d9f358e319",
+    "nvidia/Cosmos-Reason1-7B": "8fe96c1fa10db9e666b6fa6a87fea57dd9635649",
+    "nvidia/Cosmos-Predict2-2B-Multiview": "52f3731663eecdc998d9608f9b21ac4dcbdea6f1",
+    "nvidia/Cosmos-Predict2-14B-Sample-GR00T-Dreams-GR1": "926f34dd83860c5406ab4b400e156c3fd6fe6c0d",
+    "nvidia/Cosmos-Predict2-14B-Sample-GR00T-Dreams-DROID": "ebc29d30a3fab504bcc779a85bca073d14ad39f9",
+    "google-t5/t5-11b": "90f37703b3334dfe9d2b009bfcbfbf1ac9d28ea3",
+    "nvidia/Cosmos-Guardrail1": "d6d4bfa899a71454a700907664f3e88f503950cf",
+    "meta-llama/Llama-Guard-3-8B": "7327bd9f6efbbe6101dc6cc4736302b3cbb6e425",
+}
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description="Download NVIDIA Cosmos Predict2 diffusion models from Hugging Face")
+    parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--model_sizes",
         nargs="*",
@@ -69,182 +102,78 @@ def parse_args():
         "--checkpoint_dir", type=str, default="checkpoints", help="Directory to save the downloaded checkpoints."
     )
     parser.add_argument(
-        "--verify_md5", action="store_true", default=False, help="Verify MD5 checksums of existing files."
-    )
-    parser.add_argument(
         "--natten",
         action="store_true",
         default=False,
         help="Download Video2World + NATTEN (sparse attention) checkpoints.",
     )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Dry run the script and print the download commands without actually downloading the files.",
+    )
     args = parser.parse_args()
     return args
-
-
-MD5_CHECKSUM_LOOKUP = {
-    # Cosmos-Predict2 models
-    "nvidia/Cosmos-Predict2-0.6B-Text2Image/model.pt": "f93f9655fce91840723cdb28ebbfa1fe",
-    "nvidia/Cosmos-Predict2-2B-Text2Image/model.pt": "0336b218dffe32848d075ba7606c522b",
-    "nvidia/Cosmos-Predict2-14B-Text2Image/model.pt": "3bc68c3384b4985120b13f964e9d6c03",
-    # 8 variants of Video2World models
-    "nvidia/Cosmos-Predict2-2B-Video2World/model-720p-16fps.pt": "66157e5aece452a5a121cbb6fe0580ac",
-    "nvidia/Cosmos-Predict2-2B-Video2World/model-720p-10fps.pt": "1884e792fe3a57c3384c68ff1c0ef0d3",
-    "nvidia/Cosmos-Predict2-2B-Video2World/model-480p-10fps.pt": "af1e352c5a8fb52ee1de19e307731b6b",
-    "nvidia/Cosmos-Predict2-2B-Video2World/model-480p-16fps.pt": "dad6861b72d595f6fae8d91c08a58e9e",
-    "nvidia/Cosmos-Predict2-14B-Video2World/model-720p-16fps.pt": "79c86aa3c91897d9d402e70a3525ed96",
-    "nvidia/Cosmos-Predict2-14B-Video2World/model-720p-10fps.pt": "34730e3d5e65c4c590f3a88ca3fd4e74",
-    "nvidia/Cosmos-Predict2-14B-Video2World/model-480p-10fps.pt": "b1dcd8adbe82e69496532d1e237c7022",
-    "nvidia/Cosmos-Predict2-14B-Video2World/model-480p-16fps.pt": "53a04f51880272d9f4a5c4460b82966d",
-    "nvidia/Cosmos-Predict2-0.6B-Text2Image/tokenizer/tokenizer.pth": "6eddc5eaf9e9e527803184f6daa65d25",
-    "nvidia/Cosmos-Predict2-2B-Text2Image/tokenizer/tokenizer.pth": "854fcb755005951fa5b329799af6199f",
-    "nvidia/Cosmos-Predict2-14B-Text2Image/tokenizer/tokenizer.pth": "854fcb755005951fa5b329799af6199f",
-    "nvidia/Cosmos-Predict2-2B-Video2World/tokenizer/tokenizer.pth": "854fcb755005951fa5b329799af6199f",
-    "nvidia/Cosmos-Predict2-14B-Video2World/tokenizer/tokenizer.pth": "854fcb755005951fa5b329799af6199f",
-    # Video2World Sparse Variants
-    "nvidia/Cosmos-Predict2-2B-Video2World/model-720p-16fps-natten.pt": "91355cc9979f47aeb7ee991193e88305",
-    "nvidia/Cosmos-Predict2-2B-Video2World/model-720p-10fps-natten.pt": "4ef2b03da1ca0888e3a4054dc8b4b2f0",
-    "nvidia/Cosmos-Predict2-14B-Video2World/model-720p-16fps-natten.pt": "09167672edf4bcd456318d8498cb6f36",
-    "nvidia/Cosmos-Predict2-14B-Video2World/model-720p-10fps-natten.pt": "86d5e27ac75021798ab594f257600e50",
-    # Multiview models
-    "nvidia/Cosmos-Predict2-2B-Multiview/model-720p-10fps-7views-29frames.pt": "0336b218dffe32848d075ba7606c522b",
-    # Cosmos-Reason1-7B
-    "nvidia/Cosmos-Reason1-7B/model-00001-of-00004.safetensors": "90198d3b3dab5a00b7b9288cecffa5e9",
-    "nvidia/Cosmos-Reason1-7B/model-00002-of-00004.safetensors": "6bde197d212f2a83ae19585b87de500e",
-    "nvidia/Cosmos-Reason1-7B/model-00003-of-00004.safetensors": "c999ec0bc79fccf2f2cdba598d4e951f",
-    "nvidia/Cosmos-Reason1-7B/model-00004-of-00004.safetensors": "232e93dfc82361ea8b0678fffc8660ef",
-    # Cosmos-Predict2-2B-Sample-Action-Conditioned
-    "nvidia/Cosmos-Predict2-2B-Sample-Action-Conditioned/model-480p-4fps.pt": "b4db0f266cc487f1242dc09a082c6dd5",
-    # Cosmos-Predict2 Post-training models
-    "nvidia/Cosmos-Predict2-14B-Sample-GR00T-Dreams-DROID/model-720p-16fps.pt": "af799ec678f6f18e3b3cfe3c1d9c591b",
-    "nvidia/Cosmos-Predict2-14B-Sample-GR00T-Dreams-GR1/model-720p-16fps.pt": "b7f92ff4d0943ab7477ad873fb17015558ee597897782032bdfeb1db2aee0796",
-    "nvidia/Cosmos-Predict2-14B-Sample-GR00T-Dreams-DROID/tokenizer/tokenizer.pth": "854fcb755005951fa5b329799af6199f",
-    "nvidia/Cosmos-Predict2-14B-Sample-GR00T-Dreams-GR1/tokenizer/tokenizer.pth": "854fcb755005951fa5b329799af6199f",
-    # T5 text encoder
-    "google-t5/t5-11b/pytorch_model.bin": "f890878d8a162e0045a25196e27089a3",
-    # Cosmos-Guardrail1
-    "nvidia/Cosmos-Guardrail1/face_blur_filter/Resnet50_Final.pth": "bce939bc22d8cec91229716dd932e56e",
-    "nvidia/Cosmos-Guardrail1/video_content_safety_filter/safety_filter.pt": "b46dc2ad821fc3b0d946549d7ade19cf",
-    "nvidia/Cosmos-Guardrail1/video_content_safety_filter/models--google--siglip-so400m-patch14-384/snapshots/9fdffc58afc957d1a03a25b10dba0329ab15c2a3/model.safetensors": "f4c887e55e159f96453e18a1d6ca984f",
-    # Meta Llama guard
-    "meta-llama/Llama-Guard-3-8B/model-00001-of-00004.safetensors": "5748060ae47b335dc19263060c921a54",
-    "meta-llama/Llama-Guard-3-8B/model-00002-of-00004.safetensors": "89e7dce10959cab81c0d09468a873f33",
-    "meta-llama/Llama-Guard-3-8B/model-00003-of-00004.safetensors": "e7e5f50ecdb02a946d071373a52c01b8",
-    "meta-llama/Llama-Guard-3-8B/model-00004-of-00004.safetensors": "a94c830cafe5e1d8d54ea2f83378b234",
-}
-
-
-def validate_files(checkpoints_dir, model_name, verify_md5=False, **download_kwargs):
-    for key, value in MD5_CHECKSUM_LOOKUP.items():
-        if key.startswith(model_name + "/"):
-            if "allow_patterns" in download_kwargs:
-                # only check if the key matches the allow_patterns
-                relative_path = key[len(model_name + "/") :]
-                if not fnmatch.fnmatch(relative_path, download_kwargs["allow_patterns"]):
-                    continue
-            if "ignore_patterns" in download_kwargs:
-                # only check if the key does not match the ignore_patterns
-                relative_path = key[len(model_name + "/") :]
-                if any(fnmatch.fnmatch(relative_path, pattern) for pattern in download_kwargs["ignore_patterns"]):
-                    continue
-            file_path = os.path.join(checkpoints_dir, key)
-            # File must exist
-            if not os.path.exists(file_path):
-                print(f"\033[93mCheckpoint {key} does not exist.\033[0m")
-                return False
-            # Verify MD5 checksum if requested
-            if verify_md5:
-                print(f"Verifying MD5 checksum of checkpoint {key}...")
-                with open(file_path, "rb") as f:
-                    file_md5 = hashlib.md5(f.read()).hexdigest()
-                if file_md5 != value:
-                    print(f"\033[93mMD5 checksum of checkpoint {key} does not match.\033[0m")
-                    return False
-    if verify_md5:
-        print(f"\033[92mModel checkpoints for {model_name} exist with matched MD5 checksums.\033[0m")
-    else:
-        print(f"\033[92mFiles for {model_name} already exist\033[0m \033[93m(MD5 not verified).\033[0m")
-    return True
-
-
-def download_model(checkpoint_dir, repo_id, verify_md5=False, **download_kwargs):
-    local_dir = os.path.join(checkpoint_dir, repo_id)
-    try:
-        # Check if files exist and optionally verify checksums
-        if not validate_files(checkpoint_dir, repo_id, verify_md5, **download_kwargs):
-            print(f"Downloading {repo_id} to {local_dir}...")
-            snapshot_download(repo_id=repo_id, local_dir=local_dir, force_download=True, **download_kwargs)
-            print(f"\033[92mSuccessfully downloaded {repo_id}\033[0m")
-    except Exception as e:
-        print(f"\033[91mError downloading {repo_id}: {e}\033[0m")
-    print("---------------------")
-
 
 def main(args):
     # Create local checkpoints folder
     os.makedirs(args.checkpoint_dir, exist_ok=True)
 
-    # Download the Cosmos-Predict2 models
-    model_size_mapping = {"0.6B": "Cosmos-Predict2-0.6B", "2B": "Cosmos-Predict2-2B", "14B": "Cosmos-Predict2-14B"}
-    model_type_mapping = {
-        "text2image": "Text2Image",
-        "video2world": "Video2World",
-        "sample_gr00t_dreams_gr1": "Sample-GR00T-Dreams-GR1",
-        "sample_gr00t_dreams_droid": "Sample-GR00T-Dreams-DROID",
-        "multiview": "Multiview",
-    }
+    def download(repo_id: str, **download_kwargs):
+        local_dir = os.path.join(args.checkpoint_dir, repo_id)
+        print(f"Downloading {repo_id} to {local_dir}...")
+        if repo_id in REPO_ID_MAPPING:
+            revision = REPO_ID_MAPPING[repo_id]
+        else:
+            revision = huggingface_hub.HfApi().repo_info(repo_id=repo_id).sha
+            print(f"Revision: {revision}")
+        if not args.dry_run:
+            try:
+                snapshot_download(repo_id=repo_id, local_dir=local_dir, revision=revision, **download_kwargs)
+            except Exception as e:
+                print(f"\033[91mError downloading {repo_id}: {e}\033[0m")
+        print("-" * 20)
+
     if "text2image" in args.model_types:
         for size in args.model_sizes:
-            repo_id = f"nvidia/{model_size_mapping[size]}-{model_type_mapping['text2image']}"
-            download_model(args.checkpoint_dir, repo_id, verify_md5=args.verify_md5)
+            download(f"nvidia/{MODEL_SIZE_MAPPING[size]}-{MODEL_TYPE_MAPPING['text2image']}")
 
     if "video2world" in args.model_types:
         for size in args.model_sizes:
             for fps in args.fps:
                 for res in args.resolution:
-                    repo_id = f"nvidia/{model_size_mapping[size]}-{model_type_mapping['video2world']}"
-                    allow_patterns = f"model-{res}p-{fps}fps.pt"
-                    download_model(
-                        args.checkpoint_dir, repo_id, verify_md5=args.verify_md5, allow_patterns=allow_patterns
-                    )
-                    # Sparse variant (if any)
+                    allow_patterns = [f"model-{res}p-{fps}fps.pt"]
                     if args.natten and res == "720":
-                        download_model(
-                            args.checkpoint_dir,
-                            repo_id,
-                            verify_md5=args.verify_md5,
-                            allow_patterns=f"model-{res}p-{fps}fps-natten.pt",
-                        )
+                        allow_patterns.append(f"model-{res}p-{fps}fps-natten.pt")
+                    download(
+                        f"nvidia/{MODEL_SIZE_MAPPING[size]}-{MODEL_TYPE_MAPPING['video2world']}", allow_patterns=allow_patterns
+                    )
 
-            # donwload the remaining
-            repo_id = f"nvidia/{model_size_mapping[size]}-{model_type_mapping['video2world']}"
-            download_model(args.checkpoint_dir, repo_id, verify_md5=args.verify_md5, allow_patterns="tokenizer/*")
-        download_model(args.checkpoint_dir, "nvidia/Cosmos-Reason1-7B", verify_md5=args.verify_md5)
+            download(f"nvidia/{MODEL_SIZE_MAPPING[size]}-{MODEL_TYPE_MAPPING['video2world']}", allow_patterns="tokenizer/*")
+        download("nvidia/Cosmos-Reason1-7B")
     
     if "multiview" in args.model_types:
-        repo_id = f"nvidia/Cosmos-Predict2-2B-Multiview"
-        download_model(args.checkpoint_dir, repo_id, verify_md5=args.verify_md5, allow_patterns="*.pt")
+        download("nvidia/Cosmos-Predict2-2B-Multiview", allow_patterns="*.pt")
 
     if "sample_action_conditioned" in args.model_types:
-        print("NOTE: Sample Action Conditioned model is only available for 2B model size, 480P and 4FPS")
-        repo_id = "nvidia/Cosmos-Predict2-2B-Sample-Action-Conditioned"
-        download_model(args.checkpoint_dir, repo_id, verify_md5=args.verify_md5)
+        if "2B" in args.model_sizes and "480" in args.resolution and "4" in args.fps:
+            download("nvidia/Cosmos-Predict2-2B-Sample-Action-Conditioned")
+        else:
+            print("Sample Action Conditioned model is only available for 2B model size, 480P and 4FPS. Skipping...")
 
     # Download the GR00T models
     if "sample_gr00t_dreams_gr1" in args.model_types:
-        repo_id = f"nvidia/{model_size_mapping['14B']}-{model_type_mapping['sample_gr00t_dreams_gr1']}"
-        download_model(args.checkpoint_dir, repo_id, verify_md5=args.verify_md5)
-
+        download(f"nvidia/{MODEL_SIZE_MAPPING['14B']}-{MODEL_TYPE_MAPPING['sample_gr00t_dreams_gr1']}")
     if "sample_gr00t_dreams_droid" in args.model_types:
-        repo_id = f"nvidia/{model_size_mapping['14B']}-{model_type_mapping['sample_gr00t_dreams_droid']}"
-        download_model(args.checkpoint_dir, repo_id, verify_md5=args.verify_md5)
+        download(f"nvidia/{MODEL_SIZE_MAPPING['14B']}-{MODEL_TYPE_MAPPING['sample_gr00t_dreams_droid']}")
 
     # Download T5 model
-    download_model(args.checkpoint_dir, "google-t5/t5-11b", verify_md5=args.verify_md5, ignore_patterns=["tf_model.h5"])
+    download("google-t5/t5-11b", ignore_patterns=["tf_model.h5"])
 
     # Download the guardrail models
-    download_model(args.checkpoint_dir, "nvidia/Cosmos-Guardrail1", verify_md5=args.verify_md5)
-    download_model(
-        args.checkpoint_dir, "meta-llama/Llama-Guard-3-8B", verify_md5=args.verify_md5, ignore_patterns=["original/*"]
+    download("nvidia/Cosmos-Guardrail1")
+    download(
+        "meta-llama/Llama-Guard-3-8B", ignore_patterns=["original/*"]
     )
 
     print("Checkpoint downloading done.")


### PR DESCRIPTION
Add checkpoint revisions to `download_checkpoints.py` script to improve reproducibility.

* Make `download_checkpoints.py` script self-executable so it is easier to run.
* Remove `download_checkpoints.py hash checks. This check was super slow and shouldn't be necessary now that we are pinning the revisions.
* Improve readme.

## Verification

Ran `./scripts/download_checkpoints.py`.

CI: `pipelines/32859068`
CI seems to be broken on `main` as well: `pipelines/32861786`