### PR TITLE
Add instructions to post-train Video2World model using dataset from Cosmos-Curate

### DIFF
--- a/cosmos_predict2/configs/base/experiment/custom_data.py
+++ b/cosmos_predict2/configs/base/experiment/custom_data.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from hydra.core.config_store import ConfigStore
+from megatron.core import parallel_state
+from torch.utils.data import DataLoader, DistributedSampler
+
+from cosmos_predict2.data.dataset_video import Dataset
+from imaginaire.lazy_config import LazyCall as L
+
+
+def get_sampler(dataset) -> DistributedSampler:
+    return DistributedSampler(
+        dataset,
+        num_replicas=parallel_state.get_data_parallel_world_size(),
+        rank=parallel_state.get_data_parallel_rank(),
+        shuffle=True,
+        seed=0,
+    )
+
+
+cs = ConfigStore.instance()
+
+# Custom video dataset
+example_video_dataset = L(Dataset)(
+    dataset_dir="datasets/cosmos_predict2_video2world_dataset",
+    num_frames=93,
+    video_size=(704, 1280),  # 720 resolution, 16:9 aspect ratio
+)
+
+dataloader_video_train = L(DataLoader)(
+    dataset=example_video_dataset,
+    sampler=L(get_sampler)(dataset=example_video_dataset),
+    batch_size=1,
+    drop_last=True,
+    num_workers=8,
+    pin_memory=True,
+)
+
+# torchrun --nproc_per_node=8 --master_port=12341 -m scripts.train --config=cosmos_predict2/configs/base/config.py -- experiment=predict2_video2world_training_2b_custom_data
+predict2_video2world_training_2b_custom_data = dict(
+    defaults=[
+        {"override /model": "predict2_video2world_fsdp_2b"},
+        {"override /optimizer": "fusedadamw"},
+        {"override /scheduler": "lambdalinear"},
+        {"override /ckpt_type": "standard"},
+        {"override /dataloader_val": "mock"},
+        "_self_",
+    ],
+    job=dict(
+        project="posttraining",
+        group="video2world",
+        name="2b_custom_data",
+    ),
+    model=dict(
+        config=dict(
+            pipe_config=dict(
+                ema=dict(enabled=True),
+                prompt_refiner_config=dict(enabled=False),
+                guardrail_config=dict(enabled=False),
+            ),
+        )
+    ),
+    model_parallel=dict(
+        context_parallel_size=1,
+    ),
+    dataloader_train=dataloader_video_train,
+    trainer=dict(
+        distributed_parallelism="fsdp",
+        callbacks=dict(
+            iter_speed=dict(hit_thres=10),
+        ),
+        max_iter=1000,
+    ),
+    checkpoint=dict(
+        save_iter=500,
+    ),
+    optimizer=dict(
+        lr=2 ** (-14.5),
+    ),
+    scheduler=dict(
+        warm_up_steps=[0],
+        cycle_lengths=[1_000],
+        f_max=[0.6],
+        f_min=[0.0],
+    ),
+)
+
+# torchrun --nproc_per_node=8 --nnodes=4 --rdzv_id 123 --rdzv_backend c10d --rdzv_endpoint $MASTER_ADDR:1234 -m scripts.train --config=cosmos_predict2/configs/base/config.py -- experiment=predict2_video2world_training_14b_custom_data
+predict2_video2world_training_14b_custom_data = dict(
+    defaults=[
+        {"override /model": "predict2_video2world_fsdp_14b"},
+        {"override /optimizer": "fusedadamw"},
+        {"override /scheduler": "lambdalinear"},
+        {"override /ckpt_type": "standard"},
+        {"override /dataloader_val": "mock"},
+        "_self_",
+    ],
+    job=dict(
+        project="posttraining",
+        group="video2world",
+        name="14b_custom_data",
+    ),
+    model=dict(
+        config=dict(
+            pipe_config=dict(
+                ema=dict(enabled=True),
+                prompt_refiner_config=dict(enabled=False),
+                guardrail_config=dict(enabled=False),
+            ),
+        )
+    ),
+    model_parallel=dict(
+        context_parallel_size=8,
+    ),
+    dataloader_train=dataloader_video_train,
+    trainer=dict(
+        distributed_parallelism="fsdp",
+        callbacks=dict(
+            iter_speed=dict(hit_thres=10),
+        ),
+        max_iter=1000,
+    ),
+    checkpoint=dict(
+        save_iter=500,
+    ),
+    optimizer=dict(
+        lr=2 ** (-14.5),
+        weight_decay=0.2,
+    ),
+    scheduler=dict(
+        warm_up_steps=[0],
+        cycle_lengths=[1_000],
+        f_max=[0.25],
+        f_min=[0.0],
+    ),
+)
+
+for _item in [
+    # 2b, custom_data
+    predict2_video2world_training_2b_custom_data,
+    # 14b, custom_data
+    predict2_video2world_training_14b_custom_data,
+]:
+    # Get the experiment name from the global variable.
+    experiment_name = [name.lower() for name, value in globals().items() if value is _item][0]
+
+    cs.store(
+        group="experiment",
+        package="_global_",
+        name=experiment_name,
+        node=_item,
+    )

--- a/cosmos_predict2/data/dataset_video.py
+++ b/cosmos_predict2/data/dataset_video.py
@@ -134,7 +134,12 @@ class Dataset(Dataset):
 
             # Just add these to fit the interface
             with open(t5_embedding_path, "rb") as f:
-                t5_embedding = pickle.load(f)[0]  # [n_tokens, _T5_EMBED_DIM]
+                t5_embedding_raw = pickle.load(f)
+                assert isinstance(t5_embedding_raw, list)
+                assert len(t5_embedding_raw) == 1
+                t5_embedding = t5_embedding_raw[0]  # [n_tokens, _T5_EMBED_DIM]
+                assert isinstance(t5_embedding, np.ndarray)
+                assert len(t5_embedding.shape) == 2
             n_tokens = t5_embedding.shape[0]
             if n_tokens < _NUM_T5_TOKENS:
                 t5_embedding = np.concatenate(

--- a/documentations/post-training_video2world.md
+++ b/documentations/post-training_video2world.md
@@ -31,12 +31,18 @@ We support post-training the models with example datasets.
 
 ### 1. Preparing Data
 
-The post-training data is expected to contain paired prompt and video files.
+You can use [Cosmos-Curate](https://github.com/nvidia-cosmos/cosmos-curate) to generate the ready-to-train dataset from your raw videos.
+- First follow the [user guide here](https://github.com/nvidia-cosmos/cosmos-curate/blob/main/docs/client/END_USER_GUIDE.md)
+and the specific instructions in [Generate Dataset for Cosmos-Predict2 Post-Training section]() to prepare the dataset.
+- Then copy the generated `cosmos_predict2_video2world_dataset/` directory into `datasets/` directory in this repo.
+
+Alternatively, in case you want to prepare the dataset without `Cosmos-Curate`,
+the post-training data is expected to contain paired prompt and video files.
 For example, a custom dataset can be saved in a following structure.
 
 Dataset folder format:
 ```
-datasets/custom_video2world_dataset/
+datasets/cosmos_predict2_video2world_dataset/
 ├── metas/
 │   ├── *.txt
 ├── videos/
@@ -48,11 +54,11 @@ datasets/custom_video2world_dataset/
 
 After preparing `metas` and `videos` folders, run the following command to pre-compute T5-XXL embeddings.
 ```bash
-python -m scripts.get_t5_embeddings --dataset_path datasets/custom_video2world_dataset/
+python -m scripts.get_t5_embeddings --dataset_path datasets/cosmos_predict2_video2world_dataset/
 ```
 This script will create `t5_xxl` folder under the dataset root where the T5-XXL embeddings are saved as `.pickle` files.
 ```
-datasets/custom_video2world_dataset/
+datasets/cosmos_predict2_video2world_dataset/
 ├── metas/
 │   ├── *.txt
 ├── videos/
@@ -63,13 +69,18 @@ datasets/custom_video2world_dataset/
 
 ### 2. Creating Configs for Training
 
-Define dataloader from the prepared dataset.
+Note we provide an example config file for post-training with custom data
+at [cosmos_predict2/configs/base/experiment/custom_data.py](../cosmos_predict2/configs/base/experiment/custom_data.py)
+that includes the sample code below.
+But the walk-through below will help you understand how to configure the training.
+
+First, define dataloader from the prepared dataset.
 
 For example,
 ```python
 # custom dataset example
 example_video_dataset = L(Dataset)(
-    dataset_dir="datasets/custom_video2world_dataset",
+    dataset_dir="datasets/cosmos_predict2_video2world_dataset",
     num_frames=93,
     video_size=(704, 1280),  # 720 resolution, 16:9 aspect ratio
 )


### PR DESCRIPTION
- Add instructions in `documentations/post-training_video2world.md` regarding how to use Cosmos-Curate for post-training.
- Add an experiment script for post-training using custom data
- Add check when loading T5 embedding pickle since it assumes certain format for the pickle. 