### PR TITLE
PICBIR9W-1126: Remove hard-coded checkpoint paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,16 @@ Here is a quick example demonstrating how to use Cosmos-Predict2-2B-Video2World 
 
 ```python
 import torch
+from imaginaire.constants import get_cosmos_predict2_video2world_checkpoint, get_t5_model_dir
 from imaginaire.utils.io import save_image_or_video
-from cosmos_predict2.configs.base.config_video2world import PREDICT2_VIDEO2WORLD_PIPELINE_2B
+from cosmos_predict2.configs.base.config_video2world import get_cosmos_predict2_video2world_pipeline
 from cosmos_predict2.pipelines.video2world import Video2WorldPipeline
 
 # Create the video generation pipeline.
 pipe = Video2WorldPipeline.from_config(
-    config=PREDICT2_VIDEO2WORLD_PIPELINE_2B,
-    dit_path="checkpoints/nvidia/Cosmos-Predict2-2B-Video2World/model-720p-16fps.pt",
-    text_encoder_path="checkpoints/google-t5/t5-11b",
+    config=get_cosmos_predict2_video2world_pipeline(model_size="2B"),
+    dit_path=get_cosmos_predict2_video2world_checkpoint(model_size="2B"),
+    text_encoder_path=get_t5_model_dir(),
 )
 
 # Specify the input image path and text prompt.

--- a/cosmos_predict2/auxiliary/cosmos_reason1.py
+++ b/cosmos_predict2/auxiliary/cosmos_reason1.py
@@ -23,6 +23,7 @@ from transformers import (
     set_seed,
 )
 
+from imaginaire.constants import get_cosmos_reason1_model_dir
 from imaginaire.utils import log
 
 SYSTEM_PROMPT_REFINE = (
@@ -262,5 +263,5 @@ class CosmosReason1(torch.nn.Module):
 
 
 if __name__ == "__main__":
-    model = CosmosReason1("checkpoints/nvidia/Cosmos-Reason1-7B")
+    model = CosmosReason1(get_cosmos_reason1_model_dir())
     print(model.refine_prompt("assets/video2world/input0.jpg", "A bus terminal in the city."))

--- a/cosmos_predict2/auxiliary/guardrail/face_blur_filter/face_blur_filter.py
+++ b/cosmos_predict2/auxiliary/guardrail/face_blur_filter/face_blur_filter.py
@@ -33,6 +33,7 @@ from cosmos_predict2.auxiliary.guardrail.face_blur_filter.retinaface_utils impor
     filter_detected_boxes,
     load_model,
 )
+from imaginaire.constants import get_cosmos_guardrail1_model_dir
 from imaginaire.utils import log, misc
 
 # RetinaFace model constants from https://github.com/biubug6/Pytorch_Retinaface/blob/master/detect.py
@@ -218,7 +219,7 @@ def main(args):
         return
 
     face_blur = RetinaFaceFilter(
-        checkpoint_dir="checkpoints/nvidia/Cosmos-Guardrail1/face_blur_filter/Resnet50_Final.pth"
+        checkpoint_dir=f"{get_cosmos_guardrail1_model_dir()}/face_blur_filter/Resnet50_Final.pth"
     )
     postprocessing_runner = GuardrailRunner(postprocessors=[face_blur])
     os.makedirs(args.output_dir, exist_ok=True)

--- a/cosmos_predict2/auxiliary/guardrail/llamaGuard3/llamaGuard3.py
+++ b/cosmos_predict2/auxiliary/guardrail/llamaGuard3/llamaGuard3.py
@@ -21,6 +21,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from cosmos_predict2.auxiliary.guardrail.common.core import ContentSafetyGuardrail, GuardrailRunner
 from cosmos_predict2.auxiliary.guardrail.llamaGuard3.categories import UNSAFE_CATEGORIES
+from imaginaire.constants import get_llama_guard3_model_dir
 from imaginaire.utils import log, misc
 
 SAFE = misc.Color.green("SAFE")
@@ -121,7 +122,7 @@ def parse_args():
 
 
 def main(args):
-    llamaGuard3 = LlamaGuard3(checkpoint_dir="checkpoints/meta-llama/Llama-Guard-3-8B")
+    llamaGuard3 = LlamaGuard3(checkpoint_dir=get_llama_guard3_model_dir())
     runner = GuardrailRunner(safety_models=[llamaGuard3])
     with misc.timer("Llama Guard 3 safety check"):
         safety, message = runner.run_safety_check(args.prompt)

--- a/cosmos_predict2/auxiliary/guardrail/video_content_safety_filter/video_content_safety_filter.py
+++ b/cosmos_predict2/auxiliary/guardrail/video_content_safety_filter/video_content_safety_filter.py
@@ -25,6 +25,7 @@ from cosmos_predict2.auxiliary.guardrail.common.core import ContentSafetyGuardra
 from cosmos_predict2.auxiliary.guardrail.common.io_utils import get_video_filepaths, read_video
 from cosmos_predict2.auxiliary.guardrail.video_content_safety_filter.model import ModelConfig, VideoSafetyModel
 from cosmos_predict2.auxiliary.guardrail.video_content_safety_filter.vision_encoder import SigLIPEncoder
+from imaginaire.constants import get_cosmos_guardrail1_model_dir
 from imaginaire.utils import log, misc
 
 # Define the class index to class name mapping for multi-class classification
@@ -192,7 +193,7 @@ def main(args):
         return
 
     video_filter = VideoContentSafetyFilter(
-        checkpoint_dir="checkpoints/nvidia/Cosmos-Guardrail1/video_content_safety_filter"
+        checkpoint_dir=f"{get_cosmos_guardrail1_model_dir()}/video_content_safety_filter"
     )
     runner = GuardrailRunner(safety_models=[video_filter], generic_safe_msg="Video is safe")
 

--- a/cosmos_predict2/configs/action_conditioned/defaults/model.py
+++ b/cosmos_predict2/configs/action_conditioned/defaults/model.py
@@ -15,20 +15,21 @@
 
 from hydra.core.config_store import ConfigStore
 
-from cosmos_predict2.configs.action_conditioned.config import PREDICT2_VIDEO2WORLD_PIPELINE_2B_ACTION_CONDITIONED
+from cosmos_predict2.configs.action_conditioned.config import get_cosmos_predict2_action_conditioned_pipeline
 from cosmos_predict2.models.video2world_action_model import Predict2Video2WorldActionConditionedModel
 from cosmos_predict2.models.video2world_model import Predict2ModelManagerConfig, Predict2Video2WorldModelConfig
+from imaginaire.constants import get_cosmos_predict2_action_conditioned_checkpoint
 from imaginaire.lazy_config import LazyCall as L
 
-PREDICT2_V2W_2B_ACTION_CONDITIONED_FSDP_CONFIG = dict(
+_PREDICT2_V2W_2B_ACTION_CONDITIONED_FSDP_CONFIG = dict(
     trainer=dict(
         distributed_parallelism="fsdp",
     ),
     model=L(Predict2Video2WorldActionConditionedModel)(
         config=Predict2Video2WorldModelConfig(
-            pipe_config=PREDICT2_VIDEO2WORLD_PIPELINE_2B_ACTION_CONDITIONED,
+            pipe_config=get_cosmos_predict2_action_conditioned_pipeline(model_size="2B", resolution="480", fps=4),
             model_manager_config=L(Predict2ModelManagerConfig)(
-                dit_path="checkpoints/nvidia/Cosmos-Predict2-2B-Video2World/model-720p-16fps.pt",
+                dit_path=get_cosmos_predict2_action_conditioned_checkpoint(model_size="2B", resolution="480", fps=4),
                 text_encoder_path="",  # Do not load text encoder for training.
             ),
             fsdp_shard_size=-1,
@@ -45,5 +46,5 @@ def register_model_action_conditioned() -> None:
         group="model",
         package="_global_",
         name="predict2_v2w_2b_action_conditioned_fsdp",
-        node=PREDICT2_V2W_2B_ACTION_CONDITIONED_FSDP_CONFIG,
+        node=_PREDICT2_V2W_2B_ACTION_CONDITIONED_FSDP_CONFIG,
     )

--- a/cosmos_predict2/configs/base/config_text2image.py
+++ b/cosmos_predict2/configs/base/config_text2image.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
+
 import attrs
 
 from cosmos_predict2.conditioner import ReMapkey, TextAttr, TextConditioner
@@ -20,6 +22,11 @@ from cosmos_predict2.configs.base.defaults.ema import EMAConfig
 from cosmos_predict2.models.text2image_dit import MiniTrainDIT
 from cosmos_predict2.tokenizers.tokenizer import CosmosImageTokenizer, TokenizerInterface
 from imaginaire.config import make_freezable
+from imaginaire.constants import (
+    CosmosPredict2Video2WorldModelSize,
+    get_checkpoints_dir,
+    get_cosmos_predict2_text2image_tokenizer,
+)
 from imaginaire.lazy_config import LazyCall as L
 from imaginaire.lazy_config import LazyDict
 
@@ -46,9 +53,9 @@ class CosmosGuardrailConfig:
 @attrs.define(slots=False)
 class Text2ImagePipelineConfig:
     adjust_video_noise: bool
-    conditioner: LazyDict
-    net: LazyDict
-    tokenizer: LazyDict
+    conditioner: LazyDict[TextConditioner]
+    net: LazyDict[MiniTrainDIT]
+    tokenizer: LazyDict[TokenizerInterface]
     guardrail_config: CosmosGuardrailConfig
     precision: str
     rectified_flow_t_scaling_factor: float
@@ -66,7 +73,7 @@ class Text2ImagePipelineConfig:
 
 
 # Cosmos Predict2 Text2Image 0.6B
-PREDICT2_TEXT2IMAGE_NET_0P6B = L(MiniTrainDIT)(
+_PREDICT2_TEXT2IMAGE_NET_0P6B = L(MiniTrainDIT)(
     max_img_h=240,
     max_img_w=240,
     max_frames=128,
@@ -100,7 +107,7 @@ PREDICT2_TEXT2IMAGE_NET_0P6B = L(MiniTrainDIT)(
     rope_enable_fps_modulation=False,
 )
 
-PREDICT2_TEXT2IMAGE_PIPELINE_0P6B = Text2ImagePipelineConfig(
+_PREDICT2_TEXT2IMAGE_PIPELINE_0P6B = Text2ImagePipelineConfig(
     adjust_video_noise=True,
     conditioner=L(TextConditioner)(
         fps=L(ReMapkey)(
@@ -120,7 +127,7 @@ PREDICT2_TEXT2IMAGE_PIPELINE_0P6B = Text2ImagePipelineConfig(
             input_key=["t5_text_embeddings"],
         ),
     ),
-    net=PREDICT2_TEXT2IMAGE_NET_0P6B,
+    net=_PREDICT2_TEXT2IMAGE_NET_0P6B,
     precision="bfloat16",
     rectified_flow_t_scaling_factor=1.0,
     rectified_flow_loss_weight_uniform=True,
@@ -135,7 +142,7 @@ PREDICT2_TEXT2IMAGE_PIPELINE_0P6B = Text2ImagePipelineConfig(
         chunk_duration=81,
         load_mean_std=False,
         name="tokenizer",
-        vae_pth="checkpoints/nvidia/Cosmos-Predict2-0.6B-Text2Image/tokenizer/tokenizer.pth",
+        vae_pth=get_cosmos_predict2_text2image_tokenizer(model_size="0.6B"),
     ),
     guardrail_config=CosmosGuardrailConfig(
         checkpoint_dir="checkpoints/",
@@ -145,7 +152,7 @@ PREDICT2_TEXT2IMAGE_PIPELINE_0P6B = Text2ImagePipelineConfig(
 )
 
 # Config for using fast tokenizer
-PREDICT2_TEXT2IMAGE_PIPELINE_0P6B_FAST_TOKENIZER = Text2ImagePipelineConfig(
+_PREDICT2_TEXT2IMAGE_PIPELINE_0P6B_FAST_TOKENIZER = Text2ImagePipelineConfig(
     adjust_video_noise=True,
     conditioner=L(TextConditioner)(
         fps=L(ReMapkey)(
@@ -165,7 +172,7 @@ PREDICT2_TEXT2IMAGE_PIPELINE_0P6B_FAST_TOKENIZER = Text2ImagePipelineConfig(
             input_key=["t5_text_embeddings"],
         ),
     ),
-    net=PREDICT2_TEXT2IMAGE_NET_0P6B,
+    net=_PREDICT2_TEXT2IMAGE_NET_0P6B,
     precision="bfloat16",
     rectified_flow_t_scaling_factor=1.0,
     rectified_flow_loss_weight_uniform=True,
@@ -178,17 +185,17 @@ PREDICT2_TEXT2IMAGE_PIPELINE_0P6B_FAST_TOKENIZER = Text2ImagePipelineConfig(
     text_encoder_class="T5",
     tokenizer=L(CosmosImageTokenizer)(
         name="tokenizer",
-        vae_pth="checkpoints/nvidia/Cosmos-Predict2-0.6B-Text2Image/tokenizer_fast/tokenizer.pth",
+        vae_pth=get_cosmos_predict2_text2image_tokenizer(model_size="0.6B"),
     ),
     guardrail_config=CosmosGuardrailConfig(
-        checkpoint_dir="checkpoints/",
+        checkpoint_dir=get_checkpoints_dir(),
         offload_model_to_cpu=True,
         enabled=True,
     ),
 )
 
 # Cosmos Predict2 Text2Image 2B
-PREDICT2_TEXT2IMAGE_NET_2B = L(MiniTrainDIT)(
+_PREDICT2_TEXT2IMAGE_NET_2B = L(MiniTrainDIT)(
     max_img_h=240,
     max_img_w=240,
     max_frames=128,
@@ -223,7 +230,7 @@ PREDICT2_TEXT2IMAGE_NET_2B = L(MiniTrainDIT)(
     rope_enable_fps_modulation=False,
 )
 
-PREDICT2_TEXT2IMAGE_PIPELINE_2B = Text2ImagePipelineConfig(
+_PREDICT2_TEXT2IMAGE_PIPELINE_2B = Text2ImagePipelineConfig(
     adjust_video_noise=True,
     conditioner=L(TextConditioner)(
         fps=L(ReMapkey)(
@@ -243,7 +250,7 @@ PREDICT2_TEXT2IMAGE_PIPELINE_2B = Text2ImagePipelineConfig(
             input_key=["t5_text_embeddings"],
         ),
     ),
-    net=PREDICT2_TEXT2IMAGE_NET_2B,
+    net=_PREDICT2_TEXT2IMAGE_NET_2B,
     precision="bfloat16",
     rectified_flow_t_scaling_factor=1.0,
     rectified_flow_loss_weight_uniform=True,
@@ -258,17 +265,17 @@ PREDICT2_TEXT2IMAGE_PIPELINE_2B = Text2ImagePipelineConfig(
         chunk_duration=81,
         load_mean_std=False,
         name="tokenizer",
-        vae_pth="checkpoints/nvidia/Cosmos-Predict2-2B-Text2Image/tokenizer/tokenizer.pth",
+        vae_pth=get_cosmos_predict2_text2image_tokenizer(model_size="2B"),
     ),
     guardrail_config=CosmosGuardrailConfig(
-        checkpoint_dir="checkpoints/",
+        checkpoint_dir=get_checkpoints_dir(),
         offload_model_to_cpu=True,
         enabled=True,
     ),
 )
 
 # Cosmos Predict2 Text2Image 14B
-PREDICT2_TEXT2IMAGE_NET_14B = L(MiniTrainDIT)(
+_PREDICT2_TEXT2IMAGE_NET_14B = L(MiniTrainDIT)(
     max_img_h=240,
     max_img_w=240,
     max_frames=128,
@@ -302,7 +309,7 @@ PREDICT2_TEXT2IMAGE_NET_14B = L(MiniTrainDIT)(
     rope_enable_fps_modulation=False,
 )
 
-PREDICT2_TEXT2IMAGE_PIPELINE_14B = Text2ImagePipelineConfig(
+_PREDICT2_TEXT2IMAGE_PIPELINE_14B = Text2ImagePipelineConfig(
     adjust_video_noise=True,
     conditioner=L(TextConditioner)(
         fps=L(ReMapkey)(
@@ -322,7 +329,7 @@ PREDICT2_TEXT2IMAGE_PIPELINE_14B = Text2ImagePipelineConfig(
             input_key=["t5_text_embeddings"],
         ),
     ),
-    net=PREDICT2_TEXT2IMAGE_NET_14B,
+    net=_PREDICT2_TEXT2IMAGE_NET_14B,
     precision="bfloat16",
     rectified_flow_t_scaling_factor=1.0,
     rectified_flow_loss_weight_uniform=True,
@@ -337,11 +344,32 @@ PREDICT2_TEXT2IMAGE_PIPELINE_14B = Text2ImagePipelineConfig(
         chunk_duration=81,
         load_mean_std=False,
         name="tokenizer",
-        vae_pth="checkpoints/nvidia/Cosmos-Predict2-14B-Text2Image/tokenizer/tokenizer.pth",
+        vae_pth=get_cosmos_predict2_text2image_tokenizer(model_size="14B"),
     ),
     guardrail_config=CosmosGuardrailConfig(
-        checkpoint_dir="checkpoints/",
+        checkpoint_dir=get_checkpoints_dir(),
         offload_model_to_cpu=True,
         enabled=True,
     ),
 )
+
+
+@dataclasses.dataclass(frozen=True)
+class _Text2ImagePipelineConfig:
+    model_size: CosmosPredict2Video2WorldModelSize
+    fast_tokenizer: bool = dataclasses.field(default=False, kw_only=True)
+
+
+_PREDICT2_TEXT2IMAGE_PIPELINES: dict[_Text2ImagePipelineConfig, Text2ImagePipelineConfig] = {
+    _Text2ImagePipelineConfig("0.6B"): _PREDICT2_TEXT2IMAGE_PIPELINE_0P6B,
+    _Text2ImagePipelineConfig("2B"): _PREDICT2_TEXT2IMAGE_PIPELINE_2B,
+    _Text2ImagePipelineConfig("14B"): _PREDICT2_TEXT2IMAGE_PIPELINE_14B,
+    _Text2ImagePipelineConfig("0.6B", fast_tokenizer=True): _PREDICT2_TEXT2IMAGE_PIPELINE_0P6B_FAST_TOKENIZER,
+}
+
+
+def get_cosmos_predict2_text2image_pipeline(
+    *, model_size: CosmosPredict2Video2WorldModelSize, fast_tokenizer: bool = False
+) -> Text2ImagePipelineConfig:
+    key = _Text2ImagePipelineConfig(model_size, fast_tokenizer=fast_tokenizer)
+    return _PREDICT2_TEXT2IMAGE_PIPELINES[key]

--- a/cosmos_predict2/configs/base/config_video2world.py
+++ b/cosmos_predict2/configs/base/config_video2world.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
 from copy import deepcopy
 from enum import Enum
 
@@ -29,6 +30,14 @@ from cosmos_predict2.models.text2image_dit import SACConfig
 from cosmos_predict2.models.video2world_dit import MinimalV1LVGDiT
 from cosmos_predict2.tokenizers.tokenizer import TokenizerInterface
 from imaginaire.config import make_freezable
+from imaginaire.constants import (
+    CosmosPredict2Video2WorldFPS,
+    CosmosPredict2Video2WorldModelSize,
+    CosmosPredict2Video2WorldResolution,
+    get_checkpoints_dir,
+    get_cosmos_predict2_video2world_tokenizer,
+    get_cosmos_reason1_model_dir,
+)
 from imaginaire.lazy_config import LazyCall as L
 from imaginaire.lazy_config import LazyDict
 
@@ -53,13 +62,13 @@ class CosmosReason1Config:
 @attrs.define(slots=False)
 class Video2WorldPipelineConfig:
     adjust_video_noise: bool
-    conditioner: LazyDict
+    conditioner: LazyDict[VideoConditioner]
     conditioning_strategy: str
     min_num_conditional_frames: int
     max_num_conditional_frames: int
     sigma_conditional: float
-    net: LazyDict
-    tokenizer: LazyDict
+    net: LazyDict[MinimalV1LVGDiT]
+    tokenizer: LazyDict[TokenizerInterface]
     prompt_refiner_config: CosmosReason1Config
     guardrail_config: CosmosGuardrailConfig
     precision: str
@@ -78,7 +87,7 @@ class Video2WorldPipelineConfig:
 
 
 # Cosmos Predict2 Video2World 2B
-PREDICT2_VIDEO2WORLD_NET_2B = L(MinimalV1LVGDiT)(
+_PREDICT2_VIDEO2WORLD_NET_2B = L(MinimalV1LVGDiT)(
     max_img_h=240,
     max_img_w=240,
     max_frames=128,
@@ -109,7 +118,7 @@ PREDICT2_VIDEO2WORLD_NET_2B = L(MinimalV1LVGDiT)(
     ),
 )
 
-PREDICT2_VIDEO2WORLD_PIPELINE_2B = Video2WorldPipelineConfig(
+_PREDICT2_VIDEO2WORLD_PIPELINE_2B = Video2WorldPipelineConfig(
     adjust_video_noise=True,
     conditioner=L(VideoConditioner)(
         fps=L(ReMapkey)(
@@ -137,7 +146,7 @@ PREDICT2_VIDEO2WORLD_PIPELINE_2B = Video2WorldPipelineConfig(
     conditioning_strategy=str(ConditioningStrategy.FRAME_REPLACE),
     min_num_conditional_frames=1,
     max_num_conditional_frames=2,
-    net=PREDICT2_VIDEO2WORLD_NET_2B,
+    net=_PREDICT2_VIDEO2WORLD_NET_2B,
     precision="bfloat16",
     rectified_flow_t_scaling_factor=1.0,
     rectified_flow_loss_weight_uniform=True,
@@ -154,22 +163,22 @@ PREDICT2_VIDEO2WORLD_PIPELINE_2B = Video2WorldPipelineConfig(
         temporal_window=16,
         load_mean_std=False,
         name="tokenizer",
-        vae_pth="checkpoints/nvidia/Cosmos-Predict2-2B-Video2World/tokenizer/tokenizer.pth",
+        vae_pth=get_cosmos_predict2_video2world_tokenizer(model_size="2B"),
     ),
     prompt_refiner_config=CosmosReason1Config(
-        checkpoint_dir="checkpoints/nvidia/Cosmos-Reason1-7B",
+        checkpoint_dir=get_cosmos_reason1_model_dir(),
         offload_model_to_cpu=True,
         enabled=True,
     ),
     guardrail_config=CosmosGuardrailConfig(
-        checkpoint_dir="checkpoints/",
+        checkpoint_dir=get_checkpoints_dir(),
         offload_model_to_cpu=True,
         enabled=True,
     ),
 )
 
 # Cosmos Predict2 Video2World 14B
-PREDICT2_VIDEO2WORLD_NET_14B = L(MinimalV1LVGDiT)(
+_PREDICT2_VIDEO2WORLD_NET_14B = L(MinimalV1LVGDiT)(
     max_img_h=240,
     max_img_w=240,
     max_frames=128,
@@ -200,7 +209,7 @@ PREDICT2_VIDEO2WORLD_NET_14B = L(MinimalV1LVGDiT)(
     ),
 )
 
-PREDICT2_VIDEO2WORLD_PIPELINE_14B = Video2WorldPipelineConfig(
+_PREDICT2_VIDEO2WORLD_PIPELINE_14B = Video2WorldPipelineConfig(
     adjust_video_noise=True,
     conditioner=L(VideoConditioner)(
         fps=L(ReMapkey)(
@@ -228,7 +237,7 @@ PREDICT2_VIDEO2WORLD_PIPELINE_14B = Video2WorldPipelineConfig(
     conditioning_strategy=str(ConditioningStrategy.FRAME_REPLACE),
     min_num_conditional_frames=1,
     max_num_conditional_frames=2,
-    net=PREDICT2_VIDEO2WORLD_NET_14B,
+    net=_PREDICT2_VIDEO2WORLD_NET_14B,
     precision="bfloat16",
     rectified_flow_t_scaling_factor=1.0,
     rectified_flow_loss_weight_uniform=True,
@@ -245,15 +254,15 @@ PREDICT2_VIDEO2WORLD_PIPELINE_14B = Video2WorldPipelineConfig(
         temporal_window=16,
         load_mean_std=False,
         name="tokenizer",
-        vae_pth="checkpoints/nvidia/Cosmos-Predict2-14B-Video2World/tokenizer/tokenizer.pth",
+        vae_pth=get_cosmos_predict2_video2world_tokenizer(model_size="14B"),
     ),
     prompt_refiner_config=CosmosReason1Config(
-        checkpoint_dir="checkpoints/nvidia/Cosmos-Reason1-7B",
+        checkpoint_dir=get_cosmos_reason1_model_dir(),
         offload_model_to_cpu=True,
         enabled=True,
     ),
     guardrail_config=CosmosGuardrailConfig(
-        checkpoint_dir="checkpoints/",
+        checkpoint_dir=get_checkpoints_dir(),
         offload_model_to_cpu=True,
         enabled=True,
     ),
@@ -261,40 +270,40 @@ PREDICT2_VIDEO2WORLD_PIPELINE_14B = Video2WorldPipelineConfig(
 
 # Cosmos Predict2 Video2World 2B pipeline config variants - resolution ["480", "720"] and fps [10, 16]
 # 2B, resolution 480p, fps 10
-PREDICT2_VIDEO2WORLD_PIPELINE_2B_480P_10FPS = deepcopy(PREDICT2_VIDEO2WORLD_PIPELINE_2B)
-PREDICT2_VIDEO2WORLD_PIPELINE_2B_480P_10FPS.resolution = "480"
-PREDICT2_VIDEO2WORLD_PIPELINE_2B_480P_10FPS.state_t = 16
+_PREDICT2_VIDEO2WORLD_PIPELINE_2B_480P_10FPS = deepcopy(_PREDICT2_VIDEO2WORLD_PIPELINE_2B)
+_PREDICT2_VIDEO2WORLD_PIPELINE_2B_480P_10FPS.resolution = "480"
+_PREDICT2_VIDEO2WORLD_PIPELINE_2B_480P_10FPS.state_t = 16
 # 2B, resolution 480p, fps 16
-PREDICT2_VIDEO2WORLD_PIPELINE_2B_480P_16FPS = deepcopy(PREDICT2_VIDEO2WORLD_PIPELINE_2B)
-PREDICT2_VIDEO2WORLD_PIPELINE_2B_480P_16FPS.resolution = "480"
+_PREDICT2_VIDEO2WORLD_PIPELINE_2B_480P_16FPS = deepcopy(_PREDICT2_VIDEO2WORLD_PIPELINE_2B)
+_PREDICT2_VIDEO2WORLD_PIPELINE_2B_480P_16FPS.resolution = "480"
 # 2B, resolution 720p, fps 10
-PREDICT2_VIDEO2WORLD_PIPELINE_2B_720P_10FPS = deepcopy(PREDICT2_VIDEO2WORLD_PIPELINE_2B)
-PREDICT2_VIDEO2WORLD_PIPELINE_2B_720P_10FPS.state_t = 16
+_PREDICT2_VIDEO2WORLD_PIPELINE_2B_720P_10FPS = deepcopy(_PREDICT2_VIDEO2WORLD_PIPELINE_2B)
+_PREDICT2_VIDEO2WORLD_PIPELINE_2B_720P_10FPS.state_t = 16
 # 2B, resolution 720p, fps 16
-PREDICT2_VIDEO2WORLD_PIPELINE_2B_720P_16FPS = PREDICT2_VIDEO2WORLD_PIPELINE_2B
+_PREDICT2_VIDEO2WORLD_PIPELINE_2B_720P_16FPS = deepcopy(_PREDICT2_VIDEO2WORLD_PIPELINE_2B)
 
 # Cosmos Predict2 Video2World 14B pipeline config variants - resolution ["480", "720"] and fps [10, 16}]
 # 14B, resolution 480p, fps 10
-PREDICT2_VIDEO2WORLD_PIPELINE_14B_480P_10FPS = deepcopy(PREDICT2_VIDEO2WORLD_PIPELINE_14B)
-PREDICT2_VIDEO2WORLD_PIPELINE_14B_480P_10FPS.resolution = "480"
-PREDICT2_VIDEO2WORLD_PIPELINE_14B_480P_10FPS.state_t = 16
+_PREDICT2_VIDEO2WORLD_PIPELINE_14B_480P_10FPS = deepcopy(_PREDICT2_VIDEO2WORLD_PIPELINE_14B)
+_PREDICT2_VIDEO2WORLD_PIPELINE_14B_480P_10FPS.resolution = "480"
+_PREDICT2_VIDEO2WORLD_PIPELINE_14B_480P_10FPS.state_t = 16
 # 14B, resolution 480p, fps 16
-PREDICT2_VIDEO2WORLD_PIPELINE_14B_480P_16FPS = deepcopy(PREDICT2_VIDEO2WORLD_PIPELINE_14B)
-PREDICT2_VIDEO2WORLD_PIPELINE_14B_480P_16FPS.resolution = "480"
+_PREDICT2_VIDEO2WORLD_PIPELINE_14B_480P_16FPS = deepcopy(_PREDICT2_VIDEO2WORLD_PIPELINE_14B)
+_PREDICT2_VIDEO2WORLD_PIPELINE_14B_480P_16FPS.resolution = "480"
 # 14B, resolution 720p, fps 10
-PREDICT2_VIDEO2WORLD_PIPELINE_14B_720P_10FPS = deepcopy(PREDICT2_VIDEO2WORLD_PIPELINE_14B)
-PREDICT2_VIDEO2WORLD_PIPELINE_14B_720P_10FPS.state_t = 16
+_PREDICT2_VIDEO2WORLD_PIPELINE_14B_720P_10FPS = deepcopy(_PREDICT2_VIDEO2WORLD_PIPELINE_14B)
+_PREDICT2_VIDEO2WORLD_PIPELINE_14B_720P_10FPS.state_t = 16
 # 14B, resolution 720p, fps 16
-PREDICT2_VIDEO2WORLD_PIPELINE_14B_720P_16FPS = PREDICT2_VIDEO2WORLD_PIPELINE_14B
+_PREDICT2_VIDEO2WORLD_PIPELINE_14B_720P_16FPS = deepcopy(_PREDICT2_VIDEO2WORLD_PIPELINE_14B)
 
 
 # Predict2 + NATTEN
 
 # Cosmos Predict2 Video2World + NATTEN 2B
-PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_2B = deepcopy(PREDICT2_VIDEO2WORLD_NET_2B)
-PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_2B.natten_parameters = PREDICT2_VIDEO2WORLD_NET_2B_NATTEN_PARAMETERS
+_PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_2B = deepcopy(_PREDICT2_VIDEO2WORLD_PIPELINE_2B)
+_PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_2B.net.natten_parameters = PREDICT2_VIDEO2WORLD_NET_2B_NATTEN_PARAMETERS
 
-PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_2B = Video2WorldPipelineConfig(
+_PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_2B = Video2WorldPipelineConfig(
     adjust_video_noise=True,
     conditioner=L(VideoConditioner)(
         fps=L(ReMapkey)(
@@ -322,7 +331,7 @@ PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_2B = Video2WorldPipelineConfig(
     conditioning_strategy=str(ConditioningStrategy.FRAME_REPLACE),
     min_num_conditional_frames=1,
     max_num_conditional_frames=2,
-    net=PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_2B,
+    net=_PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_2B,
     precision="bfloat16",
     rectified_flow_t_scaling_factor=1.0,
     rectified_flow_loss_weight_uniform=True,
@@ -339,25 +348,25 @@ PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_2B = Video2WorldPipelineConfig(
         temporal_window=16,
         load_mean_std=False,
         name="tokenizer",
-        vae_pth="checkpoints/nvidia/Cosmos-Predict2-2B-Video2World/tokenizer/tokenizer.pth",
+        vae_pth=get_cosmos_predict2_video2world_tokenizer(model_size="2B"),
     ),
     prompt_refiner_config=CosmosReason1Config(
-        checkpoint_dir="checkpoints/nvidia/Cosmos-Reason1-7B",
+        checkpoint_dir=get_cosmos_reason1_model_dir(),
         offload_model_to_cpu=True,
         enabled=True,
     ),
     guardrail_config=CosmosGuardrailConfig(
-        checkpoint_dir="checkpoints/",
+        checkpoint_dir=get_checkpoints_dir(),
         offload_model_to_cpu=True,
         enabled=True,
     ),
 )
 
 # Cosmos Predict2 Video2World + NATTEN 14B
-PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_14B = deepcopy(PREDICT2_VIDEO2WORLD_NET_14B)
-PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_14B.natten_parameters = PREDICT2_VIDEO2WORLD_NET_14B_NATTEN_PARAMETERS
+_PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_14B = deepcopy(_PREDICT2_VIDEO2WORLD_NET_14B)
+_PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_14B.natten_parameters = PREDICT2_VIDEO2WORLD_NET_14B_NATTEN_PARAMETERS
 
-PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_14B = Video2WorldPipelineConfig(
+_PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_14B = Video2WorldPipelineConfig(
     adjust_video_noise=True,
     conditioner=L(VideoConditioner)(
         fps=L(ReMapkey)(
@@ -385,7 +394,7 @@ PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_14B = Video2WorldPipelineConfig(
     conditioning_strategy=str(ConditioningStrategy.FRAME_REPLACE),
     min_num_conditional_frames=1,
     max_num_conditional_frames=2,
-    net=PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_14B,
+    net=_PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_14B,
     precision="bfloat16",
     rectified_flow_t_scaling_factor=1.0,
     rectified_flow_loss_weight_uniform=True,
@@ -402,15 +411,15 @@ PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_14B = Video2WorldPipelineConfig(
         temporal_window=16,
         load_mean_std=False,
         name="tokenizer",
-        vae_pth="checkpoints/nvidia/Cosmos-Predict2-14B-Video2World/tokenizer/tokenizer.pth",
+        vae_pth=get_cosmos_predict2_video2world_tokenizer(model_size="14B"),
     ),
     prompt_refiner_config=CosmosReason1Config(
-        checkpoint_dir="checkpoints/nvidia/Cosmos-Reason1-7B",
+        checkpoint_dir=get_cosmos_reason1_model_dir(),
         offload_model_to_cpu=True,
         enabled=True,
     ),
     guardrail_config=CosmosGuardrailConfig(
-        checkpoint_dir="checkpoints/",
+        checkpoint_dir=get_checkpoints_dir(),
         offload_model_to_cpu=True,
         enabled=True,
     ),
@@ -419,15 +428,57 @@ PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_14B = Video2WorldPipelineConfig(
 
 # Cosmos Predict2 Video2World + NATTEN pipeline config variants
 # 2B, 720p, 10 fps
-PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_2B_720P_10FPS = deepcopy(PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_2B)
-PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_2B_720P_10FPS.state_t = 16
+_PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_2B_720P_10FPS = deepcopy(_PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_2B)
+_PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_2B_720P_10FPS.state_t = 16
 
 # 2B, 720p, 16 fps
-PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_2B_720P_16FPS = PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_2B
+_PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_2B_720P_16FPS = deepcopy(_PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_2B)
 
 # 14B, 720p, 10 fps
-PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_14B_720P_10FPS = deepcopy(PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_14B)
-PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_14B_720P_10FPS.state_t = 16
+_PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_14B_720P_10FPS = deepcopy(_PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_14B)
+_PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_14B_720P_10FPS.state_t = 16
 
 # 14B, 720p, 16 fps
-PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_14B_720P_16FPS = PREDICT2_VIDEO2WORLD_WITH_NATTEN_NET_14B
+_PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_14B_720P_16FPS = deepcopy(_PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_14B)
+
+
+@dataclasses.dataclass(frozen=True)
+class _Video2WorldPipelineConfig:
+    model_size: CosmosPredict2Video2WorldModelSize
+    resolution: CosmosPredict2Video2WorldResolution
+    fps: CosmosPredict2Video2WorldFPS
+    natten: bool = dataclasses.field(default=False, kw_only=True)
+
+
+_PREDICT2_VIDEO2WORLD_PIPELINES: dict[
+    _Video2WorldPipelineConfig,
+    Video2WorldPipelineConfig,
+] = {
+    _Video2WorldPipelineConfig("2B", "480", 10): _PREDICT2_VIDEO2WORLD_PIPELINE_2B_480P_10FPS,
+    _Video2WorldPipelineConfig("2B", "480", 16): _PREDICT2_VIDEO2WORLD_PIPELINE_2B_480P_16FPS,
+    _Video2WorldPipelineConfig("2B", "720", 10): _PREDICT2_VIDEO2WORLD_PIPELINE_2B_720P_10FPS,
+    _Video2WorldPipelineConfig("2B", "720", 16): _PREDICT2_VIDEO2WORLD_PIPELINE_2B_720P_16FPS,
+    _Video2WorldPipelineConfig("14B", "480", 10): _PREDICT2_VIDEO2WORLD_PIPELINE_14B_480P_10FPS,
+    _Video2WorldPipelineConfig("14B", "480", 16): _PREDICT2_VIDEO2WORLD_PIPELINE_14B_480P_16FPS,
+    _Video2WorldPipelineConfig("14B", "720", 10): _PREDICT2_VIDEO2WORLD_PIPELINE_14B_720P_10FPS,
+    _Video2WorldPipelineConfig("14B", "720", 16): _PREDICT2_VIDEO2WORLD_PIPELINE_14B_720P_16FPS,
+    _Video2WorldPipelineConfig("2B", "720", 10, natten=True): _PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_2B_720P_10FPS,
+    _Video2WorldPipelineConfig("2B", "720", 16, natten=True): _PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_2B_720P_16FPS,
+    _Video2WorldPipelineConfig(
+        "14B", "720", 10, natten=True
+    ): _PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_14B_720P_10FPS,
+    _Video2WorldPipelineConfig(
+        "14B", "720", 16, natten=True
+    ): _PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_14B_720P_16FPS,
+}
+
+
+def get_cosmos_predict2_video2world_pipeline(
+    *,
+    model_size: CosmosPredict2Video2WorldModelSize,
+    resolution: CosmosPredict2Video2WorldResolution = "720",
+    fps: CosmosPredict2Video2WorldFPS = 16,
+    natten: bool = False,
+) -> Video2WorldPipelineConfig:
+    key = _Video2WorldPipelineConfig(model_size, resolution, fps, natten=natten)
+    return _PREDICT2_VIDEO2WORLD_PIPELINES[key]

--- a/cosmos_predict2/configs/base/defaults/model.py
+++ b/cosmos_predict2/configs/base/defaults/model.py
@@ -15,22 +15,12 @@
 
 from hydra.core.config_store import ConfigStore
 
-from cosmos_predict2.configs.base.config_multiview import PREDICT2_MULTIVIEW_PIPELINE_2B_720P_10FPS_7VIEWS_29FRAMES
+from cosmos_predict2.configs.base.config_multiview import get_cosmos_predict2_multiview_pipeline
 from cosmos_predict2.configs.base.config_text2image import (
-    PREDICT2_TEXT2IMAGE_PIPELINE_2B,
-    PREDICT2_TEXT2IMAGE_PIPELINE_14B,
+    get_cosmos_predict2_text2image_pipeline,
 )
 from cosmos_predict2.configs.base.config_video2world import (
-    PREDICT2_VIDEO2WORLD_PIPELINE_2B,  # 720p, 16fps
-    PREDICT2_VIDEO2WORLD_PIPELINE_2B_480P_10FPS,
-    PREDICT2_VIDEO2WORLD_PIPELINE_2B_480P_16FPS,
-    PREDICT2_VIDEO2WORLD_PIPELINE_2B_720P_10FPS,
-    PREDICT2_VIDEO2WORLD_PIPELINE_2B_720P_16FPS,
-    PREDICT2_VIDEO2WORLD_PIPELINE_14B,  # 720p, 16fps
-    PREDICT2_VIDEO2WORLD_PIPELINE_14B_480P_10FPS,
-    PREDICT2_VIDEO2WORLD_PIPELINE_14B_480P_16FPS,
-    PREDICT2_VIDEO2WORLD_PIPELINE_14B_720P_10FPS,
-    PREDICT2_VIDEO2WORLD_PIPELINE_14B_720P_16FPS,
+    get_cosmos_predict2_video2world_pipeline,
 )
 from cosmos_predict2.models.multiview_model import (
     Predict2MultiviewModel,
@@ -45,18 +35,23 @@ from cosmos_predict2.models.video2world_model import (
     Predict2Video2WorldModel,
     Predict2Video2WorldModelConfig,
 )
+from imaginaire.constants import (
+    get_cosmos_predict2_multiview_checkpoint,
+    get_cosmos_predict2_text2image_checkpoint,
+    get_cosmos_predict2_video2world_checkpoint,
+)
 from imaginaire.lazy_config import LazyCall as L
 
 # 2b model config for predict2 text2image
-PREDICT2_TEXT2IMAGE_FSDP_2B = dict(
+_PREDICT2_TEXT2IMAGE_FSDP_2B = dict(
     trainer=dict(
         distributed_parallelism="fsdp",
     ),
     model=L(Predict2Text2ImageModel)(
         config=Predict2Text2ImageModelConfig(
-            pipe_config=PREDICT2_TEXT2IMAGE_PIPELINE_2B,
+            pipe_config=get_cosmos_predict2_text2image_pipeline(model_size="2B"),
             model_manager_config=L(Predict2ModelManagerConfig)(
-                dit_path="checkpoints/nvidia/Cosmos-Predict2-2B-Text2Image/model.pt",
+                dit_path=get_cosmos_predict2_text2image_checkpoint(model_size="2B"),
                 text_encoder_path="",  # Do not load text encoder for training.
             ),
             fsdp_shard_size=1,
@@ -66,15 +61,15 @@ PREDICT2_TEXT2IMAGE_FSDP_2B = dict(
 )
 
 # 14b model config for predict2 text2image
-PREDICT2_TEXT2IMAGE_FSDP_14B = dict(
+_PREDICT2_TEXT2IMAGE_FSDP_14B = dict(
     trainer=dict(
         distributed_parallelism="fsdp",
     ),
     model=L(Predict2Text2ImageModel)(
         config=Predict2Text2ImageModelConfig(
-            pipe_config=PREDICT2_TEXT2IMAGE_PIPELINE_14B,
+            pipe_config=get_cosmos_predict2_text2image_pipeline(model_size="14B"),
             model_manager_config=L(Predict2ModelManagerConfig)(
-                dit_path="checkpoints/nvidia/Cosmos-Predict2-14B-Text2Image/model.pt",
+                dit_path=get_cosmos_predict2_text2image_checkpoint(model_size="14B"),
                 text_encoder_path="",  # Do not load text encoder for training.
             ),
             fsdp_shard_size=8,
@@ -84,15 +79,15 @@ PREDICT2_TEXT2IMAGE_FSDP_14B = dict(
 )
 
 # default 2b model config for predict2 video2world (720p, 16fps)
-PREDICT2_VIDEO2WORLD_FSDP_2B = dict(
+_PREDICT2_VIDEO2WORLD_FSDP_2B = dict(
     trainer=dict(
         distributed_parallelism="fsdp",
     ),
     model=L(Predict2Video2WorldModel)(
         config=Predict2Video2WorldModelConfig(
-            pipe_config=PREDICT2_VIDEO2WORLD_PIPELINE_2B,
+            pipe_config=get_cosmos_predict2_video2world_pipeline(model_size="2B"),
             model_manager_config=L(Predict2ModelManagerConfig)(
-                dit_path="checkpoints/nvidia/Cosmos-Predict2-2B-Video2World/model-720p-16fps.pt",
+                dit_path=get_cosmos_predict2_video2world_checkpoint(model_size="2B"),
                 text_encoder_path="",  # Do not load text encoder for training.
             ),
             fsdp_shard_size=8,
@@ -103,15 +98,15 @@ PREDICT2_VIDEO2WORLD_FSDP_2B = dict(
 )
 
 # default 14b model config for predict2 video2world (720p, 16fps)
-PREDICT2_VIDEO2WORLD_FSDP_14B = dict(
+_PREDICT2_VIDEO2WORLD_FSDP_14B = dict(
     trainer=dict(
         distributed_parallelism="fsdp",
     ),
     model=L(Predict2Video2WorldModel)(
         config=Predict2Video2WorldModelConfig(
-            pipe_config=PREDICT2_VIDEO2WORLD_PIPELINE_14B,
+            pipe_config=get_cosmos_predict2_video2world_pipeline(model_size="14B"),
             model_manager_config=L(Predict2ModelManagerConfig)(
-                dit_path="checkpoints/nvidia/Cosmos-Predict2-14B-Video2World/model-720p-16fps.pt",
+                dit_path=get_cosmos_predict2_video2world_checkpoint(model_size="14B"),
                 text_encoder_path="",  # Do not load text encoder for training.
             ),
             fsdp_shard_size=32,
@@ -122,15 +117,15 @@ PREDICT2_VIDEO2WORLD_FSDP_14B = dict(
 )
 
 # 2b model configs for predict2 video2world with different resolutions and fps
-PREDICT2_VIDEO2WORLD_FSDP_2B_480P_10FPS = dict(
+_PREDICT2_VIDEO2WORLD_FSDP_2B_480P_10FPS = dict(
     trainer=dict(
         distributed_parallelism="fsdp",
     ),
     model=L(Predict2Video2WorldModel)(
         config=Predict2Video2WorldModelConfig(
-            pipe_config=PREDICT2_VIDEO2WORLD_PIPELINE_2B_480P_10FPS,
+            pipe_config=get_cosmos_predict2_video2world_pipeline(model_size="2B", resolution="480", fps=10),
             model_manager_config=L(Predict2ModelManagerConfig)(
-                dit_path="checkpoints/nvidia/Cosmos-Predict2-2B-Video2World/model-480p-10fps.pt",
+                dit_path=get_cosmos_predict2_video2world_checkpoint(model_size="2B", resolution="480", fps=10),
                 text_encoder_path="",  # Do not load text encoder for training.
             ),
             fsdp_shard_size=8,
@@ -140,15 +135,15 @@ PREDICT2_VIDEO2WORLD_FSDP_2B_480P_10FPS = dict(
     ),
 )
 
-PREDICT2_VIDEO2WORLD_FSDP_2B_480P_16FPS = dict(
+_PREDICT2_VIDEO2WORLD_FSDP_2B_480P_16FPS = dict(
     trainer=dict(
         distributed_parallelism="fsdp",
     ),
     model=L(Predict2Video2WorldModel)(
         config=Predict2Video2WorldModelConfig(
-            pipe_config=PREDICT2_VIDEO2WORLD_PIPELINE_2B_480P_16FPS,
+            pipe_config=get_cosmos_predict2_video2world_pipeline(model_size="2B", resolution="480", fps=16),
             model_manager_config=L(Predict2ModelManagerConfig)(
-                dit_path="checkpoints/nvidia/Cosmos-Predict2-2B-Video2World/model-480p-16fps.pt",
+                dit_path=get_cosmos_predict2_video2world_checkpoint(model_size="2B", resolution="480", fps=16),
                 text_encoder_path="",  # Do not load text encoder for training.
             ),
             fsdp_shard_size=8,
@@ -158,15 +153,15 @@ PREDICT2_VIDEO2WORLD_FSDP_2B_480P_16FPS = dict(
     ),
 )
 
-PREDICT2_VIDEO2WORLD_FSDP_2B_720P_10FPS = dict(
+_PREDICT2_VIDEO2WORLD_FSDP_2B_720P_10FPS = dict(
     trainer=dict(
         distributed_parallelism="fsdp",
     ),
     model=L(Predict2Video2WorldModel)(
         config=Predict2Video2WorldModelConfig(
-            pipe_config=PREDICT2_VIDEO2WORLD_PIPELINE_2B_720P_10FPS,
+            pipe_config=get_cosmos_predict2_video2world_pipeline(model_size="2B", resolution="720", fps=10),
             model_manager_config=L(Predict2ModelManagerConfig)(
-                dit_path="checkpoints/nvidia/Cosmos-Predict2-2B-Video2World/model-720p-10fps.pt",
+                dit_path=get_cosmos_predict2_video2world_checkpoint(model_size="2B", resolution="720", fps=10),
                 text_encoder_path="",  # Do not load text encoder for training.
             ),
             fsdp_shard_size=8,
@@ -176,15 +171,15 @@ PREDICT2_VIDEO2WORLD_FSDP_2B_720P_10FPS = dict(
     ),
 )
 
-PREDICT2_VIDEO2WORLD_FSDP_2B_720P_16FPS = dict(
+_PREDICT2_VIDEO2WORLD_FSDP_2B_720P_16FPS = dict(
     trainer=dict(
         distributed_parallelism="fsdp",
     ),
     model=L(Predict2Video2WorldModel)(
         config=Predict2Video2WorldModelConfig(
-            pipe_config=PREDICT2_VIDEO2WORLD_PIPELINE_2B_720P_16FPS,
+            pipe_config=get_cosmos_predict2_video2world_pipeline(model_size="2B", resolution="720", fps=16),
             model_manager_config=L(Predict2ModelManagerConfig)(
-                dit_path="checkpoints/nvidia/Cosmos-Predict2-2B-Video2World/model-720p-16fps.pt",
+                dit_path=get_cosmos_predict2_video2world_checkpoint(model_size="2B", resolution="720", fps=16),
                 text_encoder_path="",  # Do not load text encoder for training.
             ),
             fsdp_shard_size=8,
@@ -195,15 +190,15 @@ PREDICT2_VIDEO2WORLD_FSDP_2B_720P_16FPS = dict(
 )
 
 # 14b model configs for predict2 video2world with different resolutions and fps
-PREDICT2_VIDEO2WORLD_FSDP_14B_480P_10FPS = dict(
+_PREDICT2_VIDEO2WORLD_FSDP_14B_480P_10FPS = dict(
     trainer=dict(
         distributed_parallelism="fsdp",
     ),
     model=L(Predict2Video2WorldModel)(
         config=Predict2Video2WorldModelConfig(
-            pipe_config=PREDICT2_VIDEO2WORLD_PIPELINE_14B_480P_10FPS,
+            pipe_config=get_cosmos_predict2_video2world_pipeline(model_size="14B", resolution="480", fps=10),
             model_manager_config=L(Predict2ModelManagerConfig)(
-                dit_path="checkpoints/nvidia/Cosmos-Predict2-14B-Video2World/model-480p-10fps.pt",
+                dit_path=get_cosmos_predict2_video2world_checkpoint(model_size="14B", resolution="480", fps=10),
                 text_encoder_path="",  # Do not load text encoder for training.
             ),
             fsdp_shard_size=8,
@@ -213,15 +208,15 @@ PREDICT2_VIDEO2WORLD_FSDP_14B_480P_10FPS = dict(
     ),
 )
 
-PREDICT2_VIDEO2WORLD_FSDP_14B_480P_16FPS = dict(
+_PREDICT2_VIDEO2WORLD_FSDP_14B_480P_16FPS = dict(
     trainer=dict(
         distributed_parallelism="fsdp",
     ),
     model=L(Predict2Video2WorldModel)(
         config=Predict2Video2WorldModelConfig(
-            pipe_config=PREDICT2_VIDEO2WORLD_PIPELINE_14B_480P_16FPS,
+            pipe_config=get_cosmos_predict2_video2world_pipeline(model_size="14B", resolution="480", fps=16),
             model_manager_config=L(Predict2ModelManagerConfig)(
-                dit_path="checkpoints/nvidia/Cosmos-Predict2-14B-Video2World/model-480p-16fps.pt",
+                dit_path=get_cosmos_predict2_video2world_checkpoint(model_size="14B", resolution="480", fps=16),
                 text_encoder_path="",  # Do not load text encoder for training.
             ),
             fsdp_shard_size=8,
@@ -231,15 +226,15 @@ PREDICT2_VIDEO2WORLD_FSDP_14B_480P_16FPS = dict(
     ),
 )
 
-PREDICT2_VIDEO2WORLD_FSDP_14B_720P_10FPS = dict(
+_PREDICT2_VIDEO2WORLD_FSDP_14B_720P_10FPS = dict(
     trainer=dict(
         distributed_parallelism="fsdp",
     ),
     model=L(Predict2Video2WorldModel)(
         config=Predict2Video2WorldModelConfig(
-            pipe_config=PREDICT2_VIDEO2WORLD_PIPELINE_14B_720P_10FPS,
+            pipe_config=get_cosmos_predict2_video2world_pipeline(model_size="14B", resolution="720", fps=10),
             model_manager_config=L(Predict2ModelManagerConfig)(
-                dit_path="checkpoints/nvidia/Cosmos-Predict2-14B-Video2World/model-720p-10fps.pt",
+                dit_path=get_cosmos_predict2_video2world_checkpoint(model_size="14B", resolution="720", fps=10),
                 text_encoder_path="",  # Do not load text encoder for training.
             ),
             fsdp_shard_size=8,
@@ -249,15 +244,15 @@ PREDICT2_VIDEO2WORLD_FSDP_14B_720P_10FPS = dict(
     ),
 )
 
-PREDICT2_VIDEO2WORLD_FSDP_14B_720P_16FPS = dict(
+_PREDICT2_VIDEO2WORLD_FSDP_14B_720P_16FPS = dict(
     trainer=dict(
         distributed_parallelism="fsdp",
     ),
     model=L(Predict2Video2WorldModel)(
         config=Predict2Video2WorldModelConfig(
-            pipe_config=PREDICT2_VIDEO2WORLD_PIPELINE_14B_720P_16FPS,
+            pipe_config=get_cosmos_predict2_video2world_pipeline(model_size="14B", resolution="720", fps=16),
             model_manager_config=L(Predict2ModelManagerConfig)(
-                dit_path="checkpoints/nvidia/Cosmos-Predict2-14B-Video2World/model-720p-16fps.pt",
+                dit_path=get_cosmos_predict2_video2world_checkpoint(model_size="14B", resolution="720", fps=16),
                 text_encoder_path="",  # Do not load text encoder for training.
             ),
             fsdp_shard_size=8,
@@ -268,15 +263,19 @@ PREDICT2_VIDEO2WORLD_FSDP_14B_720P_16FPS = dict(
 )
 
 # 2b model configs for predict2 multiview
-PREDICT2_MULTIVIEW_FSDP_2B_720P_10FPS_7VIEWS_29FRAMES = dict(
+_PREDICT2_MULTIVIEW_FSDP_2B_720P_10FPS_7VIEWS_29FRAMES = dict(
     trainer=dict(
         distributed_parallelism="fsdp",
     ),
     model=L(Predict2MultiviewModel)(
         config=Predict2MultiviewModelConfig(
-            pipe_config=PREDICT2_MULTIVIEW_PIPELINE_2B_720P_10FPS_7VIEWS_29FRAMES,
+            pipe_config=get_cosmos_predict2_multiview_pipeline(
+                model_size="2B", resolution="720", fps=10, views=7, frames=29
+            ),
             model_manager_config=L(Predict2ModelManagerConfig)(
-                dit_path="checkpoints/nvidia/Cosmos-Predict2-2B-Multiview/model-720p-10fps-7views-29frames.pt",
+                dit_path=get_cosmos_predict2_multiview_checkpoint(
+                    model_size="2B", resolution="720", fps=10, views=7, frames=29
+                ),
                 text_encoder_path="",  # Do not load text encoder for training.
             ),
             fsdp_shard_size=8,
@@ -290,68 +289,68 @@ PREDICT2_MULTIVIEW_FSDP_2B_720P_10FPS_7VIEWS_29FRAMES = dict(
 def register_model() -> None:
     cs = ConfigStore.instance()
     # predict2 t2i 2b model
-    cs.store(group="model", package="_global_", name="predict2_text2image_fsdp_2b", node=PREDICT2_TEXT2IMAGE_FSDP_2B)
+    cs.store(group="model", package="_global_", name="predict2_text2image_fsdp_2b", node=_PREDICT2_TEXT2IMAGE_FSDP_2B)
     # predict2 t2i 14b model
-    cs.store(group="model", package="_global_", name="predict2_text2image_fsdp_14b", node=PREDICT2_TEXT2IMAGE_FSDP_14B)
+    cs.store(group="model", package="_global_", name="predict2_text2image_fsdp_14b", node=_PREDICT2_TEXT2IMAGE_FSDP_14B)
     # predict2 v2w 2b model (default 720p, 16fps)
-    cs.store(group="model", package="_global_", name="predict2_video2world_fsdp_2b", node=PREDICT2_VIDEO2WORLD_FSDP_2B)
+    cs.store(group="model", package="_global_", name="predict2_video2world_fsdp_2b", node=_PREDICT2_VIDEO2WORLD_FSDP_2B)
     # predict2 v2w 14b model (default 720p, 16fps)
     cs.store(
-        group="model", package="_global_", name="predict2_video2world_fsdp_14b", node=PREDICT2_VIDEO2WORLD_FSDP_14B
+        group="model", package="_global_", name="predict2_video2world_fsdp_14b", node=_PREDICT2_VIDEO2WORLD_FSDP_14B
     )
     # predict2 v2w 2b model by resolution and fps
     cs.store(
         group="model",
         package="_global_",
         name="predict2_video2world_fsdp_2b_480p_10fps",
-        node=PREDICT2_VIDEO2WORLD_FSDP_2B_480P_10FPS,
+        node=_PREDICT2_VIDEO2WORLD_FSDP_2B_480P_10FPS,
     )
     cs.store(
         group="model",
         package="_global_",
         name="predict2_video2world_fsdp_2b_480p_16fps",
-        node=PREDICT2_VIDEO2WORLD_FSDP_2B_480P_16FPS,
+        node=_PREDICT2_VIDEO2WORLD_FSDP_2B_480P_16FPS,
     )
     cs.store(
         group="model",
         package="_global_",
         name="predict2_video2world_fsdp_2b_720p_10fps",
-        node=PREDICT2_VIDEO2WORLD_FSDP_2B_720P_10FPS,
+        node=_PREDICT2_VIDEO2WORLD_FSDP_2B_720P_10FPS,
     )
     cs.store(
         group="model",
         package="_global_",
         name="predict2_video2world_fsdp_2b_720p_16fps",
-        node=PREDICT2_VIDEO2WORLD_FSDP_2B_720P_16FPS,
+        node=_PREDICT2_VIDEO2WORLD_FSDP_2B_720P_16FPS,
     )
     # predict2 v2w 14b model by resolution and fps
     cs.store(
         group="model",
         package="_global_",
         name="predict2_video2world_fsdp_14b_480p_10fps",
-        node=PREDICT2_VIDEO2WORLD_FSDP_14B_480P_10FPS,
+        node=_PREDICT2_VIDEO2WORLD_FSDP_14B_480P_10FPS,
     )
     cs.store(
         group="model",
         package="_global_",
         name="predict2_video2world_fsdp_14b_480p_16fps",
-        node=PREDICT2_VIDEO2WORLD_FSDP_14B_480P_16FPS,
+        node=_PREDICT2_VIDEO2WORLD_FSDP_14B_480P_16FPS,
     )
     cs.store(
         group="model",
         package="_global_",
         name="predict2_video2world_fsdp_14b_720p_10fps",
-        node=PREDICT2_VIDEO2WORLD_FSDP_14B_720P_10FPS,
+        node=_PREDICT2_VIDEO2WORLD_FSDP_14B_720P_10FPS,
     )
     cs.store(
         group="model",
         package="_global_",
         name="predict2_video2world_fsdp_14b_720p_16fps",
-        node=PREDICT2_VIDEO2WORLD_FSDP_14B_720P_16FPS,
+        node=_PREDICT2_VIDEO2WORLD_FSDP_14B_720P_16FPS,
     )
     cs.store(
         group="model",
         package="_global_",
         name="predict2_multiview_fsdp_2b_720p_10fps_7views_29frames",
-        node=PREDICT2_MULTIVIEW_FSDP_2B_720P_10FPS_7VIEWS_29FRAMES,
+        node=_PREDICT2_MULTIVIEW_FSDP_2B_720P_10FPS_7VIEWS_29FRAMES,
     )

--- a/cosmos_predict2/configs/base/defaults/optimizer.py
+++ b/cosmos_predict2/configs/base/defaults/optimizer.py
@@ -71,7 +71,7 @@ def get_base_optimizer_simple(
     return opt_cls(param_group, **kwargs)
 
 
-FusedAdamWConfig: LazyDict = L(get_base_optimizer)(
+FusedAdamWConfig: LazyDict[torch.optim.Optimizer] = L(get_base_optimizer)(
     model=PLACEHOLDER,
     lr=1e-4,
     weight_decay=0.1,

--- a/cosmos_predict2/configs/base/defaults/scheduler.py
+++ b/cosmos_predict2/configs/base/defaults/scheduler.py
@@ -17,9 +17,8 @@ from hydra.core.config_store import ConfigStore
 
 from cosmos_predict2.functional.lr_scheduler import LambdaLinearScheduler
 from imaginaire.lazy_config import LazyCall as L
-from imaginaire.lazy_config import LazyDict
 
-LambdaLinearSchedulerConfig: LazyDict = L(LambdaLinearScheduler)(
+LambdaLinearSchedulerConfig = L(LambdaLinearScheduler)(
     warm_up_steps=[1000],
     cycle_lengths=[10000000000000],
     f_start=[1.0e-6],

--- a/cosmos_predict2/configs/conditioner.py
+++ b/cosmos_predict2/configs/conditioner.py
@@ -17,7 +17,6 @@ from hydra.core.config_store import ConfigStore
 
 from cosmos_predict2.conditioner import BooleanFlag, ReMapkey, TextAttr, VideoConditioner
 from imaginaire.lazy_config import LazyCall as L
-from imaginaire.lazy_config import LazyDict
 
 _SHARED_CONFIG = dict(
     fps=L(ReMapkey)(
@@ -43,7 +42,7 @@ _SHARED_CONFIG = dict(
     ),
 )
 
-VideoPredictionConditioner: LazyDict = L(VideoConditioner)(
+VideoPredictionConditioner = L(VideoConditioner)(
     **_SHARED_CONFIG,
 )
 

--- a/cosmos_predict2/models/multiview_model.py
+++ b/cosmos_predict2/models/multiview_model.py
@@ -21,18 +21,19 @@ from megatron.core import parallel_state
 from torch.distributed.device_mesh import init_device_mesh
 
 from cosmos_predict2.configs.base.config_multiview import (
-    PREDICT2_MULTIVIEW_PIPELINE_2B_720P_10FPS_7VIEWS_29FRAMES,
     MultiviewPipelineConfig,
+    get_cosmos_predict2_multiview_pipeline,
 )
 from cosmos_predict2.models.video2world_model import Predict2Video2WorldModel
 from cosmos_predict2.pipelines.multiview import MultiviewPipeline
+from imaginaire.constants import get_cosmos_predict2_multiview_checkpoint
 from imaginaire.utils import log
 
 
 @attrs.define(slots=False)
 class Predict2ModelManagerConfig:
     # Local path, use it in fast debug run
-    dit_path: str = "checkpoints/nvidia/Cosmos-Predict2-2B-Multiview/model.pt"
+    dit_path: str = get_cosmos_predict2_multiview_checkpoint(model_size="2B")
     # For inference
     text_encoder_path: str = ""  # not used in training.
 
@@ -56,7 +57,9 @@ class Predict2MultiviewModelConfig:
     # This is used for the original way to load models
     model_manager_config: Predict2ModelManagerConfig = Predict2ModelManagerConfig()  # noqa: RUF009
     # This is a new way to load models
-    pipe_config: MultiviewPipelineConfig = PREDICT2_MULTIVIEW_PIPELINE_2B_720P_10FPS_7VIEWS_29FRAMES
+    pipe_config: MultiviewPipelineConfig = get_cosmos_predict2_multiview_pipeline(  # noqa: RUF009
+        model_size="2B", views=7, frames=29, fps=10
+    )
     # debug flag
     debug_without_randomness: bool = False
     fsdp_shard_size: int = 0  # 0 means not using fsdp, -1 means set to world size

--- a/cosmos_predict2/pipelines/text2image.py
+++ b/cosmos_predict2/pipelines/text2image.py
@@ -26,6 +26,7 @@ from tqdm import tqdm
 
 from cosmos_predict2.auxiliary.text_encoder import CosmosT5TextEncoder
 from cosmos_predict2.conditioner import DataType, TextCondition
+from cosmos_predict2.configs.base.config_text2image import Text2ImagePipelineConfig
 from cosmos_predict2.datasets.utils import IMAGE_RES_SIZE_INFO
 from cosmos_predict2.models.text2image_dit import MiniTrainDIT
 from cosmos_predict2.models.utils import init_weights_on_device, load_state_dict
@@ -84,7 +85,7 @@ class Text2ImagePipeline(BasePipeline):
 
     @staticmethod
     def from_config(
-        config: LazyDict,
+        config: LazyDict[Text2ImagePipelineConfig],
         dit_path: str = "",
         text_encoder_path: str = "",
         device: str = "cuda",

--- a/cosmos_predict2/pipelines/video2video_sdedit.py
+++ b/cosmos_predict2/pipelines/video2video_sdedit.py
@@ -26,6 +26,7 @@ from tqdm import tqdm
 from cosmos_predict2.auxiliary.cosmos_reason1 import CosmosReason1
 from cosmos_predict2.auxiliary.text_encoder import CosmosT5TextEncoder
 from cosmos_predict2.conditioner import DataType
+from cosmos_predict2.configs.base.config_text2image import Text2ImagePipelineConfig
 from cosmos_predict2.configs.base.config_video2world import Video2WorldPipelineConfig
 from cosmos_predict2.datasets.utils import IMAGE_RES_SIZE_INFO, VIDEO_RES_SIZE_INFO
 from cosmos_predict2.models.utils import init_weights_on_device, load_state_dict
@@ -209,7 +210,7 @@ def read_and_process_video_first_frames(
 class Text2ImageSDEditPipeline(Text2ImagePipeline):
     @staticmethod
     def from_config(
-        config: LazyDict,
+        config: LazyDict[Text2ImagePipelineConfig],
         dit_path: str = "",
         text_encoder_path: str = "",
         device: str = "cuda",

--- a/documentations/inference_video2world.md
+++ b/documentations/inference_video2world.md
@@ -188,7 +188,7 @@ python -m examples.video2world \
 This configuration can be seen in the model's configuration:
 ```python
 prompt_refiner_config=CosmosReason1Config(
-    checkpoint_dir="checkpoints/nvidia/Cosmos-Reason1-7B",
+    checkpoint_dir=get_cosmos_reason1_model_dir(),
     offload_model_to_cpu=True,
     enabled=True,  # Controls whether the refiner is used
 )

--- a/examples/text2world.py
+++ b/examples/text2world.py
@@ -17,6 +17,12 @@ import argparse
 import json
 import os
 
+from imaginaire.constants import (
+    CosmosPredict2Text2ImageModelSize,
+    CosmosPredict2Video2WorldFPS,
+    CosmosPredict2Video2WorldResolution,
+)
+
 # Set TOKENIZERS_PARALLELISM environment variable to avoid deadlocks with multiprocessing
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
@@ -42,7 +48,7 @@ def parse_args() -> argparse.Namespace:
     # Common arguments between text2image and video2world
     parser.add_argument(
         "--model_size",
-        choices=["2B", "14B"],
+        choices=CosmosPredict2Text2ImageModelSize.__args__,
         default="2B",
         help="Size of the model to use for text2world generation",
     )
@@ -92,14 +98,14 @@ def parse_args() -> argparse.Namespace:
     # Video2world specific arguments
     parser.add_argument(
         "--resolution",
-        choices=["480", "720"],
+        choices=CosmosPredict2Video2WorldResolution.__args__,
         default="720",
         type=str,
         help="Resolution of the model to use for video-to-world generation",
     )
     parser.add_argument(
         "--fps",
-        choices=[10, 16],
+        choices=CosmosPredict2Video2WorldFPS.__args__,
         default=16,
         type=int,
         help="FPS of the model to use for video-to-world generation",

--- a/examples/video2video_sdedit.py
+++ b/examples/video2video_sdedit.py
@@ -26,19 +26,24 @@ import torch
 import torch.distributed
 
 from cosmos_predict2.configs.base.config_text2image import (
-    PREDICT2_TEXT2IMAGE_PIPELINE_2B,
-    PREDICT2_TEXT2IMAGE_PIPELINE_14B,
+    get_cosmos_predict2_text2image_pipeline,
 )
 from cosmos_predict2.configs.base.config_video2world import (
-    PREDICT2_VIDEO2WORLD_PIPELINE_2B,
-    PREDICT2_VIDEO2WORLD_PIPELINE_14B,
-    PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_2B,
-    PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_14B,
+    get_cosmos_predict2_video2world_pipeline,
 )
 from cosmos_predict2.pipelines.video2video_sdedit import Text2ImageSDEditPipeline, Video2WorldSDEditPipeline
 
 # Import functionality from other example scripts
 from examples.video2world import _DEFAULT_NEGATIVE_PROMPT, cleanup_distributed, validate_input_file
+from imaginaire.constants import (
+    CosmosPredict2Text2ImageModelSize,
+    CosmosPredict2Video2WorldAspectRatio,
+    CosmosPredict2Video2WorldFPS,
+    CosmosPredict2Video2WorldResolution,
+    get_cosmos_predict2_text2image_checkpoint,
+    get_cosmos_predict2_video2world_checkpoint,
+    get_t5_model_dir,
+)
 from imaginaire.utils import distributed, log, misc
 from imaginaire.utils.easy_io import easy_io
 from imaginaire.utils.io import save_image_or_video, save_text_prompts
@@ -149,7 +154,7 @@ def parse_args() -> argparse.Namespace:
     # Common arguments between text2image and video2world
     parser.add_argument(
         "--model_size",
-        choices=["2B", "14B"],
+        choices=CosmosPredict2Text2ImageModelSize.__args__,
         default="2B",
         help="Size of the model to use for text2world generation",
     )
@@ -168,7 +173,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--aspect_ratio",
-        choices=["1:1", "4:3", "3:4", "16:9", "9:16"],
+        choices=CosmosPredict2Video2WorldAspectRatio.__args__,
         default="16:9",
         type=str,
         help="Aspect ratio of the generated output (width:height)",
@@ -199,14 +204,14 @@ def parse_args() -> argparse.Namespace:
     # Video2world specific arguments
     parser.add_argument(
         "--resolution",
-        choices=["480", "720"],
+        choices=CosmosPredict2Video2WorldResolution.__args__,
         default="720",
         type=str,
         help="Resolution of the model to use for video-to-world generation",
     )
     parser.add_argument(
         "--fps",
-        choices=[10, 16],
+        choices=CosmosPredict2Video2WorldFPS.__args__,
         default=16,
         type=int,
         help="FPS of the model to use for video-to-world generation",
@@ -256,54 +261,24 @@ def parse_args() -> argparse.Namespace:
 
 def setup_video2world_pipeline(args: argparse.Namespace, text_encoder=None):
     log.info(f"Using model size: {args.model_size}")
-    if hasattr(args, "natten") and args.natten:
-        assert args.model_size in ["2B", "14B"]
-        config = (
-            PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_2B
-            if args.model_size == "2B"
-            else PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_14B
-        )
-
-        config.resolution = args.resolution
-
-        if args.fps == 10:
-            config.state_t = 16
-
-        if args.resolution != "720":
-            raise NotImplementedError("Cosmos-Predict2 + NATTEN only supports 720p inference at the moment.")
-
-        if args.aspect_ratio != "16:9":
-            raise NotImplementedError("Cosmos-Predict2 + NATTEN only supports 16:9 aspect ratio at the moment.")
-
-        dit_path = (
-            f"checkpoints/nvidia/Cosmos-Predict2-{args.model_size}-Video2World/model-720p-{args.fps}fps-natten.pt"
-        )
-
-    elif args.model_size == "2B":
-        config = PREDICT2_VIDEO2WORLD_PIPELINE_2B
-
-        config.resolution = args.resolution
-        if args.fps == 10:  # default is 16 so no need to change config
-            config.state_t = 16
-
-        dit_path = f"checkpoints/nvidia/Cosmos-Predict2-2B-Video2World/model-{args.resolution}p-{args.fps}fps.pt"
-    elif args.model_size == "14B":
-        config = PREDICT2_VIDEO2WORLD_PIPELINE_14B
-
-        config.resolution = args.resolution
-        if args.fps == 10:  # default is 16 so no need to change config
-            config.state_t = 16
-
-        dit_path = f"checkpoints/nvidia/Cosmos-Predict2-14B-Video2World/model-{args.resolution}p-{args.fps}fps.pt"
-    else:
-        raise ValueError("Invalid model size. Choose either '2B' or '14B'.")
+    config = get_cosmos_predict2_video2world_pipeline(
+        model_size=args.model_size, resolution=args.resolution, fps=args.fps, natten=args.natten
+    )
     if hasattr(args, "dit_path") and args.dit_path:
         dit_path = args.dit_path
+    else:
+        dit_path = get_cosmos_predict2_video2world_checkpoint(
+            model_size=args.model_size,
+            resolution=args.resolution,
+            fps=args.fps,
+            natten=args.natten,
+            aspect_ratio=args.aspect_ratio,
+        )
 
     log.info(f"Using dit_path: {dit_path}")
 
     # Only set up text encoder path if no encoder is provided
-    text_encoder_path = None if text_encoder is not None else "checkpoints/google-t5/t5-11b"
+    text_encoder_path = None if text_encoder is not None else get_t5_model_dir()
     if text_encoder is not None:
         log.info("Using provided text encoder")
     else:
@@ -368,21 +343,15 @@ def setup_video2world_pipeline(args: argparse.Namespace, text_encoder=None):
 
 
 def setup_text2image_pipeline(args: argparse.Namespace, text_encoder=None) -> Text2ImageSDEditPipeline:
-    log.info(f"Using model size: {args.model_size}")
-    if args.model_size == "2B":
-        config = PREDICT2_TEXT2IMAGE_PIPELINE_2B
-        dit_path = "checkpoints/nvidia/Cosmos-Predict2-2B-Text2Image/model.pt"
-    elif args.model_size == "14B":
-        config = PREDICT2_TEXT2IMAGE_PIPELINE_14B
-        dit_path = "checkpoints/nvidia/Cosmos-Predict2-14B-Text2Image/model.pt"
-    else:
-        raise ValueError("Invalid model size. Choose either '2B' or '14B'.")
+    config = get_cosmos_predict2_text2image_pipeline(model_size=args.model_size)
     if hasattr(args, "dit_path") and args.dit_path:
         dit_path = args.dit_path
+    else:
+        dit_path = get_cosmos_predict2_text2image_checkpoint(model_size=args.model_size)
 
     log.info(f"Using dit_path: {dit_path}")
     # Only set up text encoder path if no encoder is provided
-    text_encoder_path = None if text_encoder is not None else "checkpoints/google-t5/t5-11b"
+    text_encoder_path = None if text_encoder is not None else get_t5_model_dir()
     if text_encoder is not None:
         log.info("Using provided text encoder")
     else:

--- a/examples/video2world.py
+++ b/examples/video2world.py
@@ -17,6 +17,15 @@ import argparse
 import json
 import os
 
+from imaginaire.constants import (
+    CosmosPredict2Video2WorldAspectRatio,
+    CosmosPredict2Video2WorldFPS,
+    CosmosPredict2Video2WorldModelSize,
+    CosmosPredict2Video2WorldResolution,
+    get_cosmos_predict2_video2world_checkpoint,
+    get_t5_model_dir,
+)
+
 # Set TOKENIZERS_PARALLELISM environment variable to avoid deadlocks with multiprocessing
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
@@ -26,10 +35,7 @@ import torch
 from megatron.core import parallel_state
 
 from cosmos_predict2.configs.base.config_video2world import (
-    PREDICT2_VIDEO2WORLD_PIPELINE_2B,
-    PREDICT2_VIDEO2WORLD_PIPELINE_14B,
-    PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_2B,
-    PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_14B,
+    get_cosmos_predict2_video2world_pipeline,
 )
 from cosmos_predict2.pipelines.video2world import _IMAGE_EXTENSIONS, _VIDEO_EXTENSIONS, Video2WorldPipeline
 from imaginaire.utils import distributed, log, misc
@@ -72,20 +78,20 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Video-to-World Generation with Cosmos Predict2")
     parser.add_argument(
         "--model_size",
-        choices=["2B", "14B"],
+        choices=CosmosPredict2Video2WorldModelSize.__args__,
         default="2B",
         help="Size of the model to use for video-to-world generation",
     )
     parser.add_argument(
         "--resolution",
-        choices=["480", "720"],
+        choices=CosmosPredict2Video2WorldResolution.__args__,
         default="720",
         type=str,
         help="Resolution of the model to use for video-to-world generation",
     )
     parser.add_argument(
         "--fps",
-        choices=[10, 16],
+        choices=CosmosPredict2Video2WorldFPS.__args__,
         default=16,
         type=int,
         help="FPS of the model to use for video-to-world generation",
@@ -121,7 +127,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--aspect_ratio",
-        choices=["1:1", "4:3", "3:4", "16:9", "9:16"],
+        choices=CosmosPredict2Video2WorldAspectRatio.__args__,
         default="16:9",
         type=str,
         help="Aspect ratio of the generated output (width:height)",
@@ -184,55 +190,23 @@ def parse_args() -> argparse.Namespace:
 
 
 def setup_pipeline(args: argparse.Namespace, text_encoder=None):
-    log.info(f"Using model size: {args.model_size}")
-    if hasattr(args, "natten") and args.natten:
-        assert args.model_size in ["2B", "14B"]
-        config = (
-            PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_2B
-            if args.model_size == "2B"
-            else PREDICT2_VIDEO2WORLD_WITH_NATTEN_PIPELINE_14B
-        )
-
-        config.resolution = args.resolution
-
-        if args.fps == 10:
-            config.state_t = 16
-
-        if args.resolution != "720":
-            raise NotImplementedError("Cosmos-Predict2 + NATTEN only supports 720p inference at the moment.")
-
-        if args.aspect_ratio != "16:9":
-            raise NotImplementedError("Cosmos-Predict2 + NATTEN only supports 16:9 aspect ratio at the moment.")
-
-        dit_path = (
-            f"checkpoints/nvidia/Cosmos-Predict2-{args.model_size}-Video2World/model-720p-{args.fps}fps-natten.pt"
-        )
-
-    elif args.model_size == "2B":
-        config = PREDICT2_VIDEO2WORLD_PIPELINE_2B
-
-        config.resolution = args.resolution
-        if args.fps == 10:  # default is 16 so no need to change config
-            config.state_t = 16
-
-        dit_path = f"checkpoints/nvidia/Cosmos-Predict2-2B-Video2World/model-{args.resolution}p-{args.fps}fps.pt"
-    elif args.model_size == "14B":
-        config = PREDICT2_VIDEO2WORLD_PIPELINE_14B
-
-        config.resolution = args.resolution
-        if args.fps == 10:  # default is 16 so no need to change config
-            config.state_t = 16
-
-        dit_path = f"checkpoints/nvidia/Cosmos-Predict2-14B-Video2World/model-{args.resolution}p-{args.fps}fps.pt"
-    else:
-        raise ValueError("Invalid model size. Choose either '2B' or '14B'.")
+    config = get_cosmos_predict2_video2world_pipeline(
+        model_size=args.model_size, resolution=args.resolution, fps=args.fps, natten=getattr(args, "natten", False)
+    )
     if hasattr(args, "dit_path") and args.dit_path:
         dit_path = args.dit_path
-
+    else:
+        dit_path = get_cosmos_predict2_video2world_checkpoint(
+            model_size=args.model_size,
+            resolution=args.resolution,
+            fps=args.fps,
+            aspect_ratio=args.aspect_ratio,
+            natten=getattr(args, "natten", False),
+        )
     log.info(f"Using dit_path: {dit_path}")
 
     # Only set up text encoder path if no encoder is provided
-    text_encoder_path = None if text_encoder is not None else "checkpoints/google-t5/t5-11b"
+    text_encoder_path = None if text_encoder is not None else get_t5_model_dir()
     if text_encoder is not None:
         log.info("Using provided text encoder")
     else:

--- a/examples/video2world_bestofn.py
+++ b/examples/video2world_bestofn.py
@@ -26,6 +26,14 @@ from typing import Any
 
 import torch
 
+from imaginaire.constants import (
+    CosmosPredict2Video2WorldAspectRatio,
+    CosmosPredict2Video2WorldFPS,
+    CosmosPredict2Video2WorldModelSize,
+    CosmosPredict2Video2WorldResolution,
+    get_cosmos_reason1_model_dir,
+)
+
 # Set TOKENIZERS_PARALLELISM environment variable to avoid deadlocks with multiprocessing
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
@@ -197,20 +205,20 @@ def parse_args():
     parser = argparse.ArgumentParser(description="Best-of-N Video Generation with Cosmos Predict2")
     parser.add_argument(
         "--model_size",
-        choices=["2B", "14B"],
+        choices=CosmosPredict2Video2WorldModelSize.__args__,
         default="2B",
         help="Size of the model to use for video-to-world generation",
     )
     parser.add_argument(
         "--resolution",
-        choices=["480", "720"],
+        choices=CosmosPredict2Video2WorldResolution.__args__,
         default="720",
         type=str,
         help="Resolution of the model to use for video-to-world generation",
     )
     parser.add_argument(
         "--fps",
-        choices=[10, 16],
+        choices=CosmosPredict2Video2WorldFPS.__args__,
         default=16,
         type=int,
         help="FPS of the model to use for video-to-world generation",
@@ -246,7 +254,7 @@ def parse_args():
     )
     parser.add_argument(
         "--aspect_ratio",
-        choices=["1:1", "4:3", "3:4", "16:9", "9:16"],
+        choices=CosmosPredict2Video2WorldAspectRatio.__args__,
         default="16:9",
         type=str,
         help="Aspect ratio of the generated output (width:height)",
@@ -299,7 +307,7 @@ def parse_args():
     parser.add_argument(
         "--checkpoint_dir",
         type=str,
-        default="checkpoints/nvidia/Cosmos-Reason1-7B",
+        default=get_cosmos_reason1_model_dir(),
         help="Path to the Cosmos-Reason1 checkpoint",
     )
     return parser.parse_args()

--- a/examples/video2world_gr00t.py
+++ b/examples/video2world_gr00t.py
@@ -24,6 +24,13 @@ import argparse
 import json
 import os
 
+from imaginaire.constants import (
+    CosmosPredict2Gr00tModelSize,
+    CosmosPredict2Video2WorldAspectRatio,
+    get_cosmos_predict2_gr00t_checkpoint,
+    get_t5_model_dir,
+)
+
 # Set TOKENIZERS_PARALLELISM environment variable to avoid deadlocks with multiprocessing
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
@@ -31,7 +38,7 @@ import torch
 from megatron.core import parallel_state
 from tqdm import tqdm
 
-from cosmos_predict2.configs.base.config_video2world import PREDICT2_VIDEO2WORLD_PIPELINE_14B
+from cosmos_predict2.configs.base.config_video2world import get_cosmos_predict2_video2world_pipeline
 from cosmos_predict2.pipelines.video2world import Video2WorldPipeline
 from examples.video2world import _DEFAULT_NEGATIVE_PROMPT, validate_input_file
 from imaginaire.utils import distributed, log, misc
@@ -42,7 +49,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="GR00T Video-to-World Generation with Cosmos Predict2")
     parser.add_argument(
         "--model_size",
-        choices=["14B"],
+        choices=CosmosPredict2Gr00tModelSize.__args__,
         default="14B",
         help="Size of the model to use for GR00T video-to-world generation",
     )
@@ -77,7 +84,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--aspect_ratio",
-        choices=["1:1", "4:3", "3:4", "16:9", "9:16"],
+        choices=CosmosPredict2Video2WorldAspectRatio.__args__,
         default="16:9",
         type=str,
         help="Aspect ratio of the generated output (width:height)",
@@ -125,24 +132,21 @@ def parse_args() -> argparse.Namespace:
 
 
 def setup_pipeline(args: argparse.Namespace):
-    log.info(f"Using model size: {args.model_size} with GR00T variant: {args.gr00t_variant}")
-
-    # Only 14B models are supported for GR00T
-    if args.model_size == "14B":
-        config = PREDICT2_VIDEO2WORLD_PIPELINE_14B
-        config.resolution = "480"  # GR00T models use 480p resolution
-        config.prompt_refiner_config.enabled = False
-
-        if args.gr00t_variant == "gr1":
-            dit_path = "checkpoints/nvidia/Cosmos-Predict2-14B-Sample-GR00T-Dreams-GR1/model-480p-16fps.pt"
-        elif args.gr00t_variant == "droid":
-            dit_path = "checkpoints/nvidia/Cosmos-Predict2-14B-Sample-GR00T-Dreams-DROID/model-480p-16fps.pt"
-    else:
-        raise ValueError("Only 14B model size is supported for GR00T variants")
-
+    resolution = "480"
+    fps = 16
+    config = get_cosmos_predict2_video2world_pipeline(model_size=args.model_size, resolution=resolution, fps=fps)
+    config.prompt_refiner_config.enabled = False
     if args.dit_path:
         dit_path = args.dit_path
-    text_encoder_path = "checkpoints/google-t5/t5-11b"
+    else:
+        dit_path = get_cosmos_predict2_gr00t_checkpoint(
+            gr00t_variant=args.gr00t_variant,
+            model_size=args.model_size,
+            resolution=resolution,
+            fps=fps,
+            aspect_ratio=args.aspect_ratio,
+        )
+    text_encoder_path = get_t5_model_dir()
     log.info(f"Loading model from: {dit_path}")
 
     misc.set_random_seed(seed=args.seed, by_rank=True)

--- a/imaginaire/config.py
+++ b/imaginaire/config.py
@@ -23,7 +23,8 @@ from typing import Any, TypeVar
 import attrs
 import torch
 import torch.utils.data
-import torch.utils.data.distributed
+
+from imaginaire.model import ImaginaireModel
 
 try:
     from megatron.core import ModelParallelConfig
@@ -319,7 +320,7 @@ class TrainerConfig:
     type: builtins.type[ImaginaireTrainer] = ImaginaireTrainer
     # Set the callback class.
     # Defaults to the callbacks below.
-    callbacks: LazyDict = LazyDict(  # noqa: RUF009
+    callbacks: LazyDict[dict[str, callback.Callback]] = LazyDict(  # noqa: RUF009
         dict(
             ema=L(callback.EMAModelCallback)(),
             progress_bar=L(callback.ProgressBarCallback)(),
@@ -364,15 +365,15 @@ class Config:
     """
 
     # Model configs.
-    model: LazyDict
+    model: LazyDict[ImaginaireModel]
     # Optimizer configs.
-    optimizer: LazyDict
+    optimizer: LazyDict[torch.optim.Optimizer]
     # Scheduler configs.
-    scheduler: LazyDict
+    scheduler: LazyDict[torch.optim.lr_scheduler.LRScheduler]
     # Training data configs.
-    dataloader_train: LazyDict
+    dataloader_train: LazyDict[torch.utils.data.DataLoader]
     # Validation data configs.
-    dataloader_val: LazyDict
+    dataloader_val: LazyDict[torch.utils.data.DataLoader]
 
     # Training job configs.
     job: JobConfig = attrs.field(factory=JobConfig)

--- a/imaginaire/constants.py
+++ b/imaginaire/constants.py
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Literal
+
+
+def get_checkpoints_dir() -> str:
+    return "checkpoints"
+
+
+def get_t5_model_dir() -> str:
+    return f"{get_checkpoints_dir()}/google-t5/t5-11b"
+
+
+def get_llama_guard3_model_dir() -> str:
+    return f"{get_checkpoints_dir()}/meta-llama/Llama-Guard-3-8B"
+
+
+def get_cosmos_guardrail1_model_dir() -> str:
+    return f"{get_checkpoints_dir()}/nvidia/Cosmos-Guardrail1"
+
+
+def get_cosmos_reason1_model_dir() -> str:
+    return f"{get_checkpoints_dir()}/nvidia/Cosmos-Reason1-7B"
+
+
+CosmosPredict2Text2ImageModelSize = Literal["2B", "14B"]
+CosmosPredict2Text2ImageModelType = Literal["Text2Image"]
+
+
+def _get_cosmos_predict2_text2image_model_dir(
+    *, model_size: CosmosPredict2Text2ImageModelSize, model_type: CosmosPredict2Text2ImageModelType = "Text2Image"
+) -> str:
+    return f"{get_checkpoints_dir()}/nvidia/Cosmos-Predict2-{model_size}-{model_type}"
+
+
+def get_cosmos_predict2_text2image_tokenizer(
+    *, model_size: CosmosPredict2Text2ImageModelSize, model_type: CosmosPredict2Text2ImageModelType = "Text2Image"
+) -> str:
+    model_dir = _get_cosmos_predict2_text2image_model_dir(model_size=model_size, model_type=model_type)
+    return f"{model_dir}/tokenizer/tokenizer.pth"
+
+
+def get_cosmos_predict2_text2image_checkpoint(
+    *, model_size: CosmosPredict2Text2ImageModelSize, model_type: CosmosPredict2Text2ImageModelType = "Text2Image"
+) -> str:
+    model_dir = _get_cosmos_predict2_text2image_model_dir(model_size=model_size, model_type=model_type)
+    return f"{model_dir}/model.pt"
+
+
+CosmosPredict2Video2WorldModelSize = Literal["0.6B", "2B", "14B"]
+CosmosPredict2Video2WorldResolution = Literal["480", "720"]
+CosmosPredict2Video2WorldFPS = Literal[10, 16]
+CosmosPredict2Video2WorldAspectRatio = Literal["1:1", "4:3", "3:4", "16:9", "9:16"]
+CosmosPredict2Video2WorldModelType = Literal["Text2Image", "Video2World", "Multiview"]
+
+
+def _get_cosmos_predict2_video2world_model_dir(
+    *,
+    model_size: CosmosPredict2Video2WorldModelSize,
+    model_type: CosmosPredict2Video2WorldModelType = "Video2World",
+) -> str:
+    return f"{get_checkpoints_dir()}/nvidia/Cosmos-Predict2-{model_size}-{model_type}"
+
+
+def get_cosmos_predict2_video2world_tokenizer(
+    *,
+    model_size: CosmosPredict2Video2WorldModelSize,
+    model_type: CosmosPredict2Video2WorldModelType = "Video2World",
+) -> str:
+    model_dir = _get_cosmos_predict2_video2world_model_dir(model_size=model_size, model_type=model_type)
+    return f"{model_dir}/tokenizer/tokenizer.pth"
+
+
+def get_cosmos_predict2_video2world_checkpoint(
+    *,
+    model_size: CosmosPredict2Video2WorldModelSize,
+    model_type: CosmosPredict2Video2WorldModelType = "Video2World",
+    resolution: CosmosPredict2Video2WorldResolution = "720",
+    fps: CosmosPredict2Video2WorldFPS = 16,
+    aspect_ratio: CosmosPredict2Video2WorldAspectRatio = "16:9",
+    natten: bool = False,
+) -> str:
+    model_dir = _get_cosmos_predict2_video2world_model_dir(model_size=model_size, model_type=model_type)
+    suffix = ""
+    if natten:
+        if aspect_ratio != "16:9":
+            raise NotImplementedError("Cosmos-Predict2 + NATTEN only supports 16:9 aspect ratio at the moment.")
+        suffix += "-natten"
+    return f"{model_dir}/model-{resolution}p-{fps}fps{suffix}.pt"
+
+
+CosmosPredict2MultiviewModelSize = Literal["2B"]
+CosmosPredict2MultiviewResolution = Literal["720"]
+CosmosPredict2MultiviewFPS = Literal[10]
+CosmosPredict2MultiviewViews = Literal[7]
+CosmosPredict2MultiviewFrames = Literal[29]
+
+
+def get_cosmos_predict2_multiview_checkpoint(
+    *,
+    model_size: CosmosPredict2MultiviewModelSize,
+    views: int = CosmosPredict2MultiviewViews,
+    frames: int = CosmosPredict2MultiviewFrames,
+    resolution: CosmosPredict2MultiviewResolution = "720",
+    fps: CosmosPredict2MultiviewFPS = 16,
+) -> str:
+    model_dir = _get_cosmos_predict2_video2world_model_dir(model_size=model_size, model_type="Multiview")
+    return f"{model_dir}/model-{resolution}p-{fps}fps-{views}views-{frames}frames.pt"
+
+
+CosmosPredict2ActionConditionedModelSize = Literal["2B"]
+CosmosPredict2ActionConditionedResolution = Literal["720"]
+CosmosPredict2ActionConditionedFPS = Literal[16]
+
+
+def get_cosmos_predict2_action_conditioned_checkpoint(
+    *,
+    model_size: CosmosPredict2ActionConditionedModelSize,
+    resolution: CosmosPredict2ActionConditionedResolution,
+    fps: CosmosPredict2ActionConditionedFPS,
+) -> str:
+    return get_cosmos_predict2_video2world_checkpoint(
+        model_size=model_size,
+        model_type="Sample-Action-Conditioned",
+        resolution=resolution,
+        fps=fps,
+    )
+
+
+CosmosPredict2Gr00tModelSize = Literal["14B"]
+CosmosPredict2Gr00tResolution = Literal["480"]
+CosmosPredict2Gr00tFPS = Literal[16]
+CosmosPredict2Gr00tAspectRatio = CosmosPredict2Video2WorldAspectRatio
+CosmosPredict2Gr00tVariant = Literal["gr1", "droid"]
+CosmosPredict2Gr00tModelType = Literal["Sample-GR00T-Dreams-GR1", "Sample-GR00T-Dreams-DROID"]
+
+_GR00T_MODEL_TYPE_MAPPING: dict[CosmosPredict2Gr00tVariant, CosmosPredict2Gr00tModelType] = {
+    "gr1": "Sample-GR00T-Dreams-GR1",
+    "droid": "Sample-GR00T-Dreams-DROID",
+}
+
+
+def get_cosmos_predict2_gr00t_checkpoint(
+    *,
+    gr00t_variant: CosmosPredict2Gr00tVariant,
+    model_size: CosmosPredict2Gr00tModelSize,
+    resolution: CosmosPredict2Video2WorldResolution,
+    fps: CosmosPredict2Video2WorldFPS,
+    aspect_ratio: CosmosPredict2Gr00tAspectRatio,
+) -> str:
+    return get_cosmos_predict2_video2world_checkpoint(
+        model_size=model_size,
+        model_type=_GR00T_MODEL_TYPE_MAPPING[gr00t_variant],
+        resolution=resolution,
+        fps=fps,
+        aspect_ratio=aspect_ratio,
+    )

--- a/imaginaire/lazy_config/__init__.py
+++ b/imaginaire/lazy_config/__init__.py
@@ -15,16 +15,15 @@
 
 import os
 
-from omegaconf import DictConfig, OmegaConf
+from omegaconf import OmegaConf
 
 from imaginaire.lazy_config.instantiate import instantiate
-from imaginaire.lazy_config.lazy import LazyCall, LazyConfig
+from imaginaire.lazy_config.lazy import LazyCall, LazyConfig, LazyDict
 from imaginaire.lazy_config.omegaconf_patch import to_object
 
 OmegaConf.to_object = to_object
 
 PLACEHOLDER = None
-LazyDict = DictConfig
 
 __all__ = ["PLACEHOLDER", "LazyCall", "LazyConfig", "LazyDict", "instantiate"]
 

--- a/imaginaire/model.py
+++ b/imaginaire/model.py
@@ -36,7 +36,9 @@ class ImaginaireModel(torch.nn.Module):
         super().__init__()
 
     def init_optimizer_scheduler(
-        self, optimizer_config: LazyDict, scheduler_config: LazyDict
+        self,
+        optimizer_config: LazyDict[torch.optim.Optimizer],
+        scheduler_config: LazyDict[torch.optim.lr_scheduler.LRScheduler],
     ) -> tuple[torch.optim.Optimizer, torch.optim.lr_scheduler.LRScheduler]:
         """Creates the optimizer and scheduler for the model.
 

--- a/scripts/get_t5_embeddings.py
+++ b/scripts/get_t5_embeddings.py
@@ -20,6 +20,7 @@ import pickle
 import numpy as np
 
 from cosmos_predict2.auxiliary.text_encoder import CosmosT5TextEncoder
+from imaginaire.constants import get_t5_model_dir
 
 """example command
 python -m scripts.get_t5_embeddings --dataset_path datasets/hdvila
@@ -30,9 +31,7 @@ def parse_args() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Compute T5 embeddings for text prompts")
     parser.add_argument("--dataset_path", type=str, default="datasets/hdvila", help="Root path to the dataset")
     parser.add_argument("--max_length", type=int, default=512, help="Maximum length of the text embedding")
-    parser.add_argument(
-        "--cache_dir", type=str, default="checkpoints/google-t5/t5-11b", help="Directory to cache the T5 model"
-    )
+    parser.add_argument("--cache_dir", type=str, default=get_t5_model_dir(), help="Directory to cache the T5 model")
     return parser.parse_args()
 
 

--- a/scripts/get_t5_embeddings_from_cosmos_nemo_assets.py
+++ b/scripts/get_t5_embeddings_from_cosmos_nemo_assets.py
@@ -20,6 +20,7 @@ import pickle
 import numpy as np
 
 from cosmos_predict2.auxiliary.text_encoder import CosmosT5TextEncoder
+from imaginaire.constants import get_t5_model_dir
 
 """example command
 python -m scripts.get_t5_embeddings_from_cosmos_nemo_assets --dataset_path datasets/cosmos_nemo_assets
@@ -36,9 +37,7 @@ def parse_args() -> argparse.ArgumentParser:
     )
     parser.add_argument("--max_length", type=int, default=512, help="Maximum length of the text embedding")
     parser.add_argument("--prompt", type=str, default="A video of sks teal robot.", help="Text prompt for the dataset")
-    parser.add_argument(
-        "--cache_dir", type=str, default="checkpoints/google-t5/t5-11b", help="Directory to cache the T5 model"
-    )
+    parser.add_argument("--cache_dir", type=str, default=get_t5_model_dir(), help="Directory to cache the T5 model")
     parser.add_argument("--is_image", action="store_true", help="Set if the dataset is image-based")
     return parser.parse_args()
 

--- a/scripts/get_t5_embeddings_from_groot_dataset.py
+++ b/scripts/get_t5_embeddings_from_groot_dataset.py
@@ -21,6 +21,7 @@ import numpy as np
 from tqdm import tqdm
 
 from cosmos_predict2.auxiliary.text_encoder import CosmosT5TextEncoder
+from imaginaire.constants import get_t5_model_dir
 
 """example command
 python -m scripts.get_t5_embeddings_from_groot_dataset --dataset_path datasets/benchmark_train/gr1
@@ -36,9 +37,7 @@ def parse_args() -> argparse.ArgumentParser:
         "--prompt_prefix", type=str, default="The robot arm is performing a task. ", help="Prefix of the prompt"
     )
     parser.add_argument("--max_length", type=int, default=512, help="Maximum length of the text embedding")
-    parser.add_argument(
-        "--cache_dir", type=str, default="checkpoints/google-t5/t5-11b", help="Directory to cache the T5 model"
-    )
+    parser.add_argument("--cache_dir", type=str, default=get_t5_model_dir(), help="Directory to cache the T5 model")
     parser.add_argument(
         "--meta_csv", type=str, default="datasets/benchmark_train/gr1/metadata.csv", help="Metadata csv file"
     )


### PR DESCRIPTION
* Abstract out hard-coded checkpoint paths and pipeline configs.
* Improve type annotations for `LazyDict`.

## Verification

GitLab CI: `pipelines/33342574`

No functional changes. Regressions should be caught by CI.

Manually ran a post-training example on feature/main, and the loss numbers are nearly identical.