### PR TITLE
Mitigate `OSError` in `imaginaire.utils.distributed.init`.

### DIFF
--- a/imaginaire/utils/distributed.py
+++ b/imaginaire/utils/distributed.py
@@ -58,7 +58,7 @@ def init() -> int | None:
     try:
         device = Device(local_rank)
         os.sched_setaffinity(0, device.get_cpu_affinity())
-    except pynvml.NVMLError as e:
+    except (OSError, pynvml.NVMLError) as e:
         log.warning(f"Failed to set device affinity: {e}")
     # Set up NCCL communication.
     os.environ["TORCH_NCCL_BLOCKING_WAIT"] = "0"


### PR DESCRIPTION
Hi team,

We've been experiencing an `OSError` when running the code on SLURM. This one-line solution resolves the issue.

Please let me know if there is a better way to fix this.

Thanks!