### PR TITLE
download_checkpoints allow --fps 4 for action-conditioned checkpoint

### DIFF
--- a/scripts/download_checkpoints.py
+++ b/scripts/download_checkpoints.py
@@ -93,7 +93,7 @@ def parse_args():
         "--fps",
         nargs="*",
         default=["16"],
-        choices=["10", "16"],
+        choices=["4", "10", "16"],
         help="Which fps to download. This is only for Video2World models and will be ignored for other model_types",
     )
     parser.add_argument(


### PR DESCRIPTION
**Problem:** To download the Cosmos-Predict2-2B-Sample-Action-Conditioned model using the [scripts/download_checkpoints.py](https://github.com/nvidia-cosmos/cosmos-predict2/blob/main/scripts/download_checkpoints.py) script as instructed in the [setup](url) one needs to set --fps 4, as shown in lines 167-171 of [scripts/download_checkpoints.py](https://github.com/nvidia-cosmos/cosmos-predict2/blob/main/scripts/download_checkpoints.py)
```python
    if "sample_action_conditioned" in args.model_types:
        if "2B" in args.model_sizes and "480" in args.resolution and "4" in args.fps:
            download("nvidia/Cosmos-Predict2-2B-Sample-Action-Conditioned")
        else:
            print("Sample Action Conditioned model is only available for 2B model size, 480P and 4FPS. Skipping...")
```

However, the parser only accepts 10 or 16 as options, as seen in line 96:
```python
        choices=["10", "16"],
```

**Fix:**
Add 4 to the list of choices in the parser argument.

