### PR TITLE
Add 4-bit Quantization Support for Single RTX 4090 Inference

### DIFF
--- a/documentations/quantization.md
+++ b/documentations/quantization.md
@@ -1,0 +1,36 @@
+# 4-bit Quantization for Single GPU Inference
+
+## Overview
+This guide enables running Cosmos-Predict2 2B on a **single RTX 4090** (24GB) using 4-bit quantization.
+
+## Hardware Requirements
+- **Minimum**: 1x RTX 4090 (24GB VRAM)
+
+## Quick Start
+
+### Single RTX 4090:
+```bash
+python examples/video2world.py \
+  --model_size 2B \
+  --quantization 4bit \
+  --quantization_double_quant \
+  --input_path "image.jpg" \
+  --prompt "Your creative prompt" \
+  --resolution 480 \
+  --disable_guardrail \
+  --disable_prompt_refiner
+```
+
+### Multi-GPU (when available):
+```bash
+export CUDA_VISIBLE_DEVICES=0,1
+python examples/video2world.py \
+  --quantization 4bit \
+  [other args...]
+```
+
+## Technical Details
+- Uses BitsAndBytes NF4 quantization
+- Environment variable based configuration
+- Backward compatible (no quantization by default)
+- Proper device mapping for multi-GPU setups


### PR DESCRIPTION
Enables running Cosmos-Predict2 2B on single RTX 4090(24GB VRAM) 


Changes Made
- Added `--quantization` argument (4bit/8bit/none)
- Added `--quantization_compute_dtype` and `--quantization_double_quant` options  
- Implemented BitsAndBytes NF4 quantization for T5 text encoder
- Backward compatible - no breaking changes

## Usage Examples

### Single RTX 4090:
```bash
python examples/video2world.py \
  --model_size 2B \
  --quantization 4bit \
  --quantization_double_quant \
  --input_path "image.jpg" \
  --prompt "Your prompt" \
  --resolution 480 \
  --disable_guardrail \
  --disable_prompt_refiner
```

### Multi-GPU:
```bash
export CUDA_VISIBLE_DEVICES=0,1
python examples/video2world.py --quantization 4bit [args...]
```

## Documentation
Added guide in `documantations/quantization.md`

## Dependencies
- `bitsandbytes` 
- `accelerate` 

https://github.com/user-attachments/assets/5ac5e909-ce4d-44b0-abc3-d56353969739

